### PR TITLE
Pass $HOME and make things relative to it

### DIFF
--- a/common/gobuild.py
+++ b/common/gobuild.py
@@ -55,7 +55,7 @@ def build(parent, source_dir, target):
     # compile...
     env = {
       "PATH": os.environ["PATH"],
-      "GOPATH": os.path.abspath(parent),
+      "GOPATH": os.environ["HOME"]+"/go",
       "GOCACHE": "/tmp",
       "GO111MODULE": "off"
     }

--- a/golang1.13/bin/compile
+++ b/golang1.13/bin/compile
@@ -76,7 +76,7 @@ def build(source_dir, target_dir):
 
     env = {
       "GOROOT": "/usr/local/go",
-      "GOPATH": "/home/go",
+      "GOPATH": os.environ["HOME"]+"/go",
       "PATH": os.environ["PATH"],
       "GOCACHE": "/tmp",
       "GO111MODULE": "on"

--- a/golang1.15/bin/compile
+++ b/golang1.15/bin/compile
@@ -76,7 +76,7 @@ def build(source_dir, target_dir):
 
     env = {
       "GOROOT": "/usr/local/go",
-      "GOPATH": "/home/go",
+      "GOPATH": os.environ["HOME"]+"/go",
       "PATH": os.environ["PATH"],
       "GOCACHE": "/tmp",
       "GO111MODULE": "on"

--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -72,6 +72,9 @@ func NewActionProxy(baseDir string, compiler string, outFile *os.File, errFile *
 
 //SetEnv sets the environment
 func (ap *ActionProxy) SetEnv(env map[string]interface{}) {
+	// Propagate some basic runtime environment
+	ap.env["HOME"] = os.Getenv("HOME")
+
 	// Propagate proxy version
 	ap.env["__OW_PROXY_VERSION"] = Version
 	// propagate OW_EXECUTION_ENV as  __OW_EXECUTION_ENV
@@ -190,9 +193,9 @@ func (ap *ActionProxy) ExtractAndCompileIO(r io.Reader, w io.Writer, main string
 
 	envMap := make(map[string]interface{})
 	if env != "" {
-	    json.Unmarshal([]byte(env), &envMap)
+		json.Unmarshal([]byte(env), &envMap)
 	}
-    ap.SetEnv(envMap)
+	ap.SetEnv(envMap)
 
 	// extract and compile it
 	file, err := ap.ExtractAndCompile(&in, main)

--- a/openwhisk/compiler.go
+++ b/openwhisk/compiler.go
@@ -53,7 +53,7 @@ func (ap *ActionProxy) CompileAction(main string, srcDir string, binDir string) 
 
 	var cmd *exec.Cmd
 	cmd = exec.Command(ap.compiler, main, srcDir, binDir)
-	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	cmd.Env = []string{"HOME=" + os.Getenv("HOME"), "PATH=" + os.Getenv("PATH")}
 	for k, v := range ap.env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}


### PR DESCRIPTION
Currently, $GOPATH is hardcoded to the root user's home directory. However, if that home directory needs to be moved (for example because / is not writable anymore), we fail.

This makes the runtime a bit more flexible wrt. honoring whatever the container environment gives it.