### PR TITLE
Log the sentinels in the child process rather than the proxy process

### DIFF
--- a/golang1.15/lib/launcher.go
+++ b/golang1.15/lib/launcher.go
@@ -118,5 +118,8 @@ func main() {
 			log.Printf("<<<'%s'<<<", output)
 		}
 		fmt.Fprintf(out, "%s\n", output)
+
+		fmt.Fprintln(os.Stdout, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+		fmt.Fprintln(os.Stderr, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
 	}
 }

--- a/golang1.17/lib/launcher.go
+++ b/golang1.17/lib/launcher.go
@@ -118,5 +118,8 @@ func main() {
 			log.Printf("<<<'%s'<<<", output)
 		}
 		fmt.Fprintf(out, "%s\n", output)
+
+		fmt.Fprintln(os.Stdout, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+		fmt.Fprintln(os.Stderr, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
 	}
 }

--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -101,8 +101,6 @@ func (proc *Executor) Interact(in []byte) ([]byte, error) {
 	case <-proc.exited:
 		err = errors.New("command exited")
 	}
-	proc.cmd.Stdout.Write([]byte(OutputGuard))
-	proc.cmd.Stderr.Write([]byte(OutputGuard))
 	return out, err
 }
 

--- a/openwhisk/executor_test.go
+++ b/openwhisk/executor_test.go
@@ -60,8 +60,6 @@ func ExampleNewExecutor_bc() {
 	// Output:
 	// <nil>
 	// 4
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
 }
 
 func ExampleNewExecutor_hello() {
@@ -77,8 +75,6 @@ func ExampleNewExecutor_hello() {
 	// <nil>
 	// {"hello": "Mike"}
 	// msg=hello Mike
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
 }
 
 func ExampleNewExecutor_env() {
@@ -93,8 +89,6 @@ func ExampleNewExecutor_env() {
 	// Output:
 	// <nil>
 	// { "env": "TEST_HELLO=WORLD TEST_HI=ALL"}
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
 }
 
 func ExampleNewExecutor_ack() {
@@ -144,6 +138,4 @@ func ExampleNewExecutor_helloack() {
 	// <nil>
 	// {"hello": "Mike"}
 	// msg=hello Mike
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
 }


### PR DESCRIPTION
The child process (aka the process executing the function) is communicating through 4 pipes with the outside world:

- stdin for getting work
- fd3 for writing responses out
- stdout and stderr for writing log output

The only synchronization happening between those pipes is the go-proxy writing into stdin and then waiting for a response to arrive at fd3. However, the arrival of the result is no guarantee that the log pipes (stdout and stderr) are consistent in that all the data in there has been flushed. Therefore, writing the sentinels inside of the go-proxy is inherently racing what's happening inside the respective function.

To fix this, we should change all function runtime implementations to write the log sentinels after writing the result to fd3 but before reading the next request. We can then guarantee that when we see these sentinels, all log lines have been dealt with.

This'll require concerted changes to Python and PHP as well (for now).