### PR TITLE
Exit non-zero on build errors, show stderr

### DIFF
--- a/golang1.15/bin/compile
+++ b/golang1.15/bin/compile
@@ -83,17 +83,16 @@ def build(source_dir, target_dir):
     }
 
     gomod = "%s/go.mod" % source_dir
-    with open(os.devnull, "w") as dn:
-        if exists(gomod):
-            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
-            if ret != 0:
-                print("cannot download modules")
-                return
-        else:
-            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
-            if ret != 0:
-                print("cannot init modules")
-                return
+    if exists(gomod):
+        ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
+        if ret != 0:
+            print("cannot download modules")
+            sys.exit(ret)
+    else:
+        ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
+        if ret != 0:
+            print("cannot init modules")
+            sys.exit(ret)
 
     ldflags = "-s -w"
     gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
@@ -102,6 +101,7 @@ def build(source_dir, target_dir):
     ret = subprocess.call(gobuild, cwd=source_dir, env=env)
     if ret != 0:
         print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
+        sys.exit(ret)
 
 def debug(source_dir, target_dir, port):
     source_dir = os.path.abspath(source_dir)

--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -83,17 +83,16 @@ def build(source_dir, target_dir):
     }
 
     gomod = "%s/go.mod" % source_dir
-    with open(os.devnull, "w") as dn:
-        if exists(gomod):
-            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
-            if ret != 0:
-                print("cannot download modules")
-                return
+    if exists(gomod):
+        ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
+        if ret != 0:
+            print("cannot download modules")
+            sys.exit(ret)
         else:
-            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
             if ret != 0:
                 print("cannot init modules")
-                return
+                sys.exit(ret)
 
     ldflags = "-s -w"
     gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
@@ -102,6 +101,7 @@ def build(source_dir, target_dir):
     ret = subprocess.call(gobuild, cwd=source_dir, env=env)
     if ret != 0:
         print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
+        sys.exit(ret)
 
 def debug(source_dir, target_dir, port):
     source_dir = os.path.abspath(source_dir)


### PR DESCRIPTION
The python script in `/bin/compile` doesn't set a non-zero exit code when the compilation fails.   Also, it swallows the output of the module download or init steps.   Although was probably ok in the original action loop context for which it was written, it is a problem when run as a subroutine of remote build because it is then being driven indirectly by a developer who may need to diagnose the failure.   Remote build uses the exit code to decide if the build failed and will then return the output of the build to the developer.

This PR changes the scripts for go 1.15 and 1.17 to correct these problems.