### PR TITLE
Forward PATH to the launcher process as well

### DIFF
--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -74,6 +74,7 @@ func NewActionProxy(baseDir string, compiler string, outFile *os.File, errFile *
 func (ap *ActionProxy) SetEnv(env map[string]interface{}) {
 	// Propagate some basic runtime environment
 	ap.env["HOME"] = os.Getenv("HOME")
+	ap.env["PATH"] = os.Getenv("PATH")
 
 	// Propagate proxy version
 	ap.env["__OW_PROXY_VERSION"] = Version


### PR DESCRIPTION
This is a stepping stone needed to transform the Node.js runtime to an actionloop. It's generally non destructive though, so we might as well do it anyway.