### PR TITLE
SERVERLESS-354 Implement log shipping inside the go-proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 )

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/openwhisk/_test/remotelogging.sh
+++ b/openwhisk/_test/remotelogging.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo '{"ok":true}' >&3
+while read line
+do
+  echo "hello from stdout"
+  echo "hello from stderr" 1>&2
+  echo "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+  echo "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX" 1>&2
+  echo '{"hello": "markus"}' >&3
+done

--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -118,9 +118,6 @@ func (proc *Executor) setupRemoteLogging(env map[string]string) error {
 	// A chunky buffer in order to not block execution of the function from dealing with log lines.
 	proc.lines = make(chan LogLine, 128)
 
-	// TODO: Should we throw stdout and stderr into one bucket? We'd lose the ability to
-	// distinguish them but, I think, we'd gain the ability to ensure that the ordering is
-	// equal to how the lines are ordered in-code (if it mixes stdout and stderr).
 	proc.cmd.Stdout = nil
 	stdout, err := proc.cmd.StdoutPipe()
 	if err != nil {

--- a/openwhisk/executor_test.go
+++ b/openwhisk/executor_test.go
@@ -204,7 +204,7 @@ func TestExecutorRemoteLoggingError(t *testing.T) {
 	assert.Equal(t, []string{"Failed to process logs: failed to send log to remote location: an error", logSentinel}, fileToLines(stderr), "local stderr not as expected")
 }
 
-func TestExecutorRemoteLoggingSetupErrorsLogtail(t *testing.T) {
+func TestExecutorRemoteLoggingSetupErrors(t *testing.T) {
 	tests := []struct {
 		service       string
 		wantErrorLine string

--- a/openwhisk/executor_test.go
+++ b/openwhisk/executor_test.go
@@ -201,7 +201,7 @@ func TestExecutorRemoteLoggingError(t *testing.T) {
 	proc.Stop()
 
 	assert.Equal(t, []string{remoteLogNotice, logSentinel}, fileToLines(stdout), "local stdout not as expected")
-	assert.Equal(t, []string{"Failed to process logs: failed to send log to remote location: an error", logSentinel}, fileToLines(stderr), "local stderr not as expected")
+	assert.Equal(t, []string{"Failed to process logs: 2 errors occurred:", "\t* an error", "\t* an error", logSentinel}, fileToLines(stderr), "local stderr not as expected")
 }
 
 func TestExecutorRemoteLoggingSetupErrors(t *testing.T) {

--- a/openwhisk/logging.go
+++ b/openwhisk/logging.go
@@ -75,10 +75,6 @@ type RemoteLogger interface {
 	// Send sends a logline to the remote service. Implementations can choose to batch
 	// lines.
 	Send(LogLine) error
-
-	// Flush force sends all potentially batched lines. This can be used to hurry up
-	// sending at the end of an activation.
-	Flush() error
 }
 
 // httpLogger sends a logline per HTTP request. No batching is done.
@@ -114,10 +110,5 @@ func (l *httpLogger) Send(line LogLine) error {
 	if res.StatusCode >= 300 {
 		return fmt.Errorf("failed to ingest log line, code: %d", res.StatusCode)
 	}
-	return nil
-}
-
-func (l *httpLogger) Flush() error {
-	// Nothing to flush. We're sending per line anyway.
 	return nil
 }

--- a/openwhisk/logging.go
+++ b/openwhisk/logging.go
@@ -1,0 +1,123 @@
+package openwhisk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type LogLine struct {
+	Message      string
+	Time         time.Time
+	Stream       string
+	ActionName   string
+	ActivationId string
+}
+
+type LogtailLogLine struct {
+	Message      string `json:"message,omitempty"`
+	Time         string `json:"dt,omitempty"`
+	Host         string `json:"host,omitempty"`
+	AppName      string `json:"appname,omitempty"`
+	ActivationId string `json:"activationId,omitempty"`
+}
+
+func FormatLogtail(l LogLine) ([]byte, error) {
+	return json.Marshal(LogtailLogLine{
+		Message:      l.Message,
+		Time:         l.Time.UTC().Format("2006-01-02 15:04:05.000000000 MST"),
+		Host:         l.ActionName,
+		AppName:      l.ActionName,
+		ActivationId: l.ActivationId,
+	})
+}
+
+type DatadogLogLine struct {
+	Message string `json:"message,omitempty"`
+	Date    int64  `json:"date,omitempty"`
+	Source  string `json:"ddsource,omitempty"`
+	Service string `json:"service,omitempty"`
+	Tags    string `json:"ddtags,omitempty"`
+}
+
+func FormatDatadog(l LogLine) ([]byte, error) {
+	if strings.HasPrefix(l.Message, "{") {
+		var current map[string]interface{}
+		if err := json.Unmarshal([]byte(l.Message), &current); err != nil {
+			// Fall back to a raw line if the JSON can't be parsed.
+			return formatDatadogRaw(l)
+		}
+		current["date"] = l.Time.UnixMilli()
+		current["ddsource"] = l.ActionName
+		current["ddtags"] = fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId)
+		current["service"] = l.ActionName
+
+		return json.Marshal(current)
+	}
+
+	return formatDatadogRaw(l)
+}
+
+func formatDatadogRaw(l LogLine) ([]byte, error) {
+	return json.Marshal(DatadogLogLine{
+		Message: l.Message,
+		Date:    l.Time.UnixMilli(),
+		Source:  l.ActionName,
+		Service: l.ActionName,
+		Tags:    fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId),
+	})
+}
+
+type RemoteLogger interface {
+	// Send sends a logline to the remote service. Implementations can choose to batch
+	// lines.
+	Send(LogLine) error
+
+	// Flush force sends all potentially batched lines. This can be used to hurry up
+	// sending at the end of an activation.
+	Flush() error
+}
+
+// httpLogger sends a logline per HTTP request. No batching is done.
+// TODO: Does batching help with log ordering?
+type httpLogger struct {
+	http    *http.Client
+	url     string
+	headers map[string]string
+	format  func(LogLine) ([]byte, error)
+}
+
+func (l *httpLogger) Send(line LogLine) error {
+	by, err := l.format(line)
+	if err != nil {
+		return fmt.Errorf("failed to marshal logline: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, l.url, bytes.NewBuffer(by))
+	if err != nil {
+		return fmt.Errorf("failed to construct HTTP request: %w", err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+	for key, val := range l.headers {
+		req.Header.Add(key, val)
+	}
+
+	res, err := l.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 300 {
+		return fmt.Errorf("failed to ingest log line, code: %d", res.StatusCode)
+	}
+	return nil
+}
+
+func (l *httpLogger) Flush() error {
+	// Nothing to flush. We're sending per line anyway.
+	return nil
+}

--- a/openwhisk/logging.go
+++ b/openwhisk/logging.go
@@ -50,7 +50,7 @@ func FormatDatadog(l LogLine) ([]byte, error) {
 			// Fall back to a raw line if the JSON can't be parsed.
 			return formatDatadogRaw(l)
 		}
-		current["date"] = l.Time.UnixMilli()
+		current["date"] = l.Time.UnixNano() / int64(time.Millisecond)
 		current["ddsource"] = l.ActionName
 		current["ddtags"] = fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId)
 		current["service"] = l.ActionName
@@ -64,7 +64,7 @@ func FormatDatadog(l LogLine) ([]byte, error) {
 func formatDatadogRaw(l LogLine) ([]byte, error) {
 	return json.Marshal(DatadogLogLine{
 		Message: l.Message,
-		Date:    l.Time.UnixMilli(),
+		Date:    l.Time.UnixNano() / int64(time.Millisecond),
 		Source:  l.ActionName,
 		Service: l.ActionName,
 		Tags:    fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId),

--- a/openwhisk/logging_test.go
+++ b/openwhisk/logging_test.go
@@ -1,0 +1,97 @@
+package openwhisk
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDatadogJSON(t *testing.T) {
+	by, err := FormatDatadog(LogLine{
+		Message:      `{"message": "foo", "attribute": "bar"}`,
+		Time:         time.Unix(0, 0),
+		Stream:       "stdout",
+		ActionName:   "testaction",
+		ActivationId: "testid",
+	})
+	assert.NoError(t, err, "failed to format log line")
+
+	var got map[string]interface{}
+	assert.NoError(t, json.Unmarshal(by, &got), "failed to unmarshal log line")
+
+	want := map[string]interface{}{
+		"message":   "foo", // This and 'attribute' are flattened into the structure.
+		"attribute": "bar",
+		"date":      float64(0), // Generic parsing transforms numbers into float64.
+		"ddtags":    "host:testaction,activationid:testid",
+		"ddsource":  "testaction",
+		"service":   "testaction",
+	}
+
+	assert.Equal(t, want, got)
+}
+
+func TestHttpLoggerSend(t *testing.T) {
+	req := make(chan *http.Request, 1)
+	format := FormatLogtail
+	logger := &httpLogger{
+		http: &http.Client{Transport: testTransport(func(r *http.Request) (*http.Response, error) {
+			req <- r
+			return httptest.NewRecorder().Result(), nil
+		})},
+		format: format,
+	}
+
+	line := LogLine{
+		Message:      "Hello World",
+		Time:         time.Time{},
+		Stream:       "stdout",
+		ActionName:   "sample/test",
+		ActivationId: "abcdef",
+	}
+	assert.NoError(t, logger.Send(line), "failed to send log")
+
+	body, err := ioutil.ReadAll((<-req).Body)
+	assert.NoError(t, err, "failed to read request body")
+
+	wantBytes, err := format(line)
+	assert.NoError(t, err, "failed to marshal log line")
+
+	assert.Equal(t, body, wantBytes)
+}
+
+func TestHttpLoggerSendError(t *testing.T) {
+	logger := &httpLogger{
+		http: &http.Client{Transport: testTransport(func(r *http.Request) (*http.Response, error) {
+			return nil, errors.New("an error")
+		})},
+		format: FormatLogtail,
+	}
+
+	assert.Error(t, logger.Send(LogLine{}))
+}
+
+func TestHttpLoggerSendHttpError(t *testing.T) {
+	logger := &httpLogger{
+		http: &http.Client{Transport: testTransport(func(r *http.Request) (*http.Response, error) {
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(http.StatusUnauthorized)
+			return rec.Result(), nil
+		})},
+		format: FormatLogtail,
+	}
+
+	assert.Error(t, logger.Send(LogLine{}))
+}
+
+type testTransport func(*http.Request) (*http.Response, error)
+
+func (t testTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return t(r)
+}


### PR DESCRIPTION
This is a first whack at an actual implementation. There are some open questions marked as TODO but I wanted to get this out of my local development to allow people to take a first look at things.

---

This is a first implementation of 3rd party log-shipping inside the go-proxy. If the respective env vars are set, stdout and stderr from the function process are intercepted and written to the service as configured.

This contains initial support for DataDog, Papertrail and Logtail. Only HTTPS transport is currently supported.