### PR TITLE
SERVERLESS-961 Implement batching for the HTTP logger

### DIFF
--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -47,6 +47,9 @@ const (
 	datadogSiteEnv           = "DD_SITE"
 	datadogApiKeyEnv         = "DD_API_KEY"
 
+	// This value is somewhat arbitrarily set now. It's low'ish to allow the logs to be written
+	// in parallel to the actual action running to amortize the timing cost of writing the logs
+	// to the backend.
 	logBatchInterval = 100 * time.Millisecond
 	// Datadog limits the size of a batch to 5 MB, so we leave some slack to that.
 	logBatchSizeLimit = 4 * 1024 * 1024

--- a/openwhisk/logging.go
+++ b/openwhisk/logging.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -75,10 +76,12 @@ type RemoteLogger interface {
 	// Send sends a logline to the remote service. Implementations can choose to batch
 	// lines.
 	Send(LogLine) error
+
+	// Flush sends all potentially buffered log lines to the remote service.
+	Flush() error
 }
 
 // httpLogger sends a logline per HTTP request. No batching is done.
-// TODO: Does batching help with log ordering?
 type httpLogger struct {
 	http    *http.Client
 	url     string
@@ -93,6 +96,115 @@ func (l *httpLogger) Send(line LogLine) error {
 	}
 
 	req, err := http.NewRequest(http.MethodPost, l.url, bytes.NewBuffer(by))
+	if err != nil {
+		return fmt.Errorf("failed to construct HTTP request: %w", err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+	for key, val := range l.headers {
+		req.Header.Add(key, val)
+	}
+
+	res, err := l.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 300 {
+		return fmt.Errorf("failed to ingest log line, code: %d", res.StatusCode)
+	}
+	return nil
+}
+
+func (l *httpLogger) Flush() error {
+	return nil
+}
+
+type batchType int
+
+const (
+	batchTypeArray batchType = iota
+	batchTypeNewline
+)
+
+type batchingHttpLogger struct {
+	http    *http.Client
+	url     string
+	headers map[string]string
+	format  func(LogLine) ([]byte, error)
+
+	batchType      batchType
+	batchInterval  time.Duration
+	batchSizeLimit int
+	execAfter      func(time.Duration, func()) *time.Timer
+
+	mux   sync.Mutex
+	timer *time.Timer
+	buf   bytes.Buffer
+}
+
+func (l *batchingHttpLogger) Send(line LogLine) error {
+	l.mux.Lock()
+	defer l.mux.Unlock()
+
+	formatted, err := l.format(line)
+	if err != nil {
+		return fmt.Errorf("failed to marshal logline: %w", err)
+	}
+
+	// Send immediately if our batch would exceed the defined limit.
+	if l.batchSizeLimit > 0 && l.buf.Len()+len(formatted) > l.batchSizeLimit {
+		if err := l.sendBatch(); err != nil {
+			return err
+		}
+	}
+
+	if l.batchType == batchTypeArray {
+		if l.buf.Len() == 0 {
+			l.buf.WriteByte('[')
+		} else {
+			l.buf.WriteByte(',')
+		}
+	} else {
+		if l.buf.Len() > 0 {
+			l.buf.WriteByte('\n')
+		}
+	}
+	l.buf.Write(formatted)
+
+	if l.timer == nil {
+		l.timer = l.execAfter(l.batchInterval, func() { l.Flush() })
+	}
+
+	return nil
+}
+
+func (l *batchingHttpLogger) Flush() error {
+	l.mux.Lock()
+	defer l.mux.Unlock()
+
+	if l.timer != nil {
+		l.timer.Stop()
+		l.timer = nil
+	}
+
+	if l.buf.Len() > 0 {
+		return l.sendBatch()
+	}
+	return nil
+}
+
+// sendBatch sends the batch to the remote.
+// mux must be held.
+func (l *batchingHttpLogger) sendBatch() error {
+	defer l.buf.Reset()
+
+	// Write the closing bracket if we're writing
+	if l.batchType == batchTypeArray {
+		l.buf.WriteByte(']')
+	}
+
+	req, err := http.NewRequest(http.MethodPost, l.url, &l.buf)
 	if err != nil {
 		return fmt.Errorf("failed to construct HTTP request: %w", err)
 	}

--- a/openwhisk/logging_test.go
+++ b/openwhisk/logging_test.go
@@ -1,6 +1,7 @@
 package openwhisk
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -90,8 +91,138 @@ func TestHttpLoggerSendHttpError(t *testing.T) {
 	assert.Error(t, logger.Send(LogLine{}))
 }
 
+func TestBatchingHttpLoggerSend(t *testing.T) {
+	bodies := make(chan string, 1)
+	scheduledFlushs := make(chan func(), 1)
+	format := FormatLogtail
+	logger := &batchingHttpLogger{
+		http: &http.Client{Transport: testTransport(func(r *http.Request) (*http.Response, error) {
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err, "failed to read request body")
+			bodies <- string(body)
+			return httptest.NewRecorder().Result(), nil
+		})},
+		format:    format,
+		batchType: batchTypeNewline,
+		execAfter: testExecAfter(scheduledFlushs),
+	}
+
+	line := LogLine{
+		Message:      "Hello World",
+		Time:         time.Time{},
+		Stream:       "stdout",
+		ActionName:   "sample/test",
+		ActivationId: "abcdef",
+	}
+	assert.NoError(t, logger.Send(line), "failed to send first log")
+	assert.NoError(t, logger.Send(line), "failed to send second log")
+
+	var buf bytes.Buffer
+	wantLine, err := format(line)
+	assert.NoError(t, err, "failed to marshal log line")
+	buf.Write(wantLine)
+	buf.WriteByte('\n')
+	buf.Write(wantLine)
+
+	// Execute the scheduled flush.
+	(<-scheduledFlushs)()
+
+	assert.Equal(t, buf.String(), <-bodies)
+
+	// Write another log
+	assert.NoError(t, logger.Send(line), "failed to send third log")
+	(<-scheduledFlushs)()
+	assert.Equal(t, string(wantLine), <-bodies)
+}
+
+func TestBatchingHttpLoggerArraySend(t *testing.T) {
+	bodies := make(chan string, 1)
+	format := FormatLogtail
+	logger := &batchingHttpLogger{
+		http: &http.Client{Transport: testTransport(func(r *http.Request) (*http.Response, error) {
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err, "failed to read request body")
+			bodies <- string(body)
+			return httptest.NewRecorder().Result(), nil
+		})},
+		format:    format,
+		batchType: batchTypeArray,
+		execAfter: testExecAfter(nil),
+	}
+
+	line := LogLine{
+		Message:      "Hello World",
+		Time:         time.Time{},
+		Stream:       "stdout",
+		ActionName:   "sample/test",
+		ActivationId: "abcdef",
+	}
+	assert.NoError(t, logger.Send(line), "failed to send first log")
+	assert.NoError(t, logger.Send(line), "failed to send second log")
+
+	var buf bytes.Buffer
+	wantLine, err := format(line)
+	assert.NoError(t, err, "failed to marshal log line")
+	buf.WriteByte('[')
+	buf.Write(wantLine)
+	buf.WriteByte(',')
+	buf.Write(wantLine)
+	buf.WriteByte(']')
+
+	// Force a flush.
+	assert.NoError(t, logger.Flush(), "failed to flush")
+
+	assert.Equal(t, buf.String(), <-bodies)
+}
+
+func TestBatchingHttpLoggerSendExceedLimit(t *testing.T) {
+	bodies := make(chan string, 2)
+	format := FormatLogtail
+	logger := &batchingHttpLogger{
+		http: &http.Client{Transport: testTransport(func(r *http.Request) (*http.Response, error) {
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err, "failed to read request body")
+			bodies <- string(body)
+			return httptest.NewRecorder().Result(), nil
+		})},
+		format:         format,
+		batchType:      batchTypeNewline,
+		batchSizeLimit: 150, // fits just one entry
+		execAfter:      testExecAfter(nil),
+	}
+
+	line := LogLine{
+		Message:      "Hello World",
+		Time:         time.Time{},
+		Stream:       "stdout",
+		ActionName:   "sample/test",
+		ActivationId: "abcdef",
+	}
+	assert.NoError(t, logger.Send(line), "failed to send first log")
+	assert.NoError(t, logger.Send(line), "failed to send second log")
+
+	wantLine, err := format(line)
+	assert.NoError(t, err, "failed to marshal log line")
+
+	// First log is written without even flushing.
+	assert.Equal(t, string(wantLine), <-bodies, "first log not as expected")
+
+	// Force the second line out of the buffer.
+	assert.NoError(t, logger.Flush(), "failed to flush")
+	assert.Equal(t, string(wantLine), <-bodies, "second log not as expected")
+}
+
 type testTransport func(*http.Request) (*http.Response, error)
 
 func (t testTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	return t(r)
+}
+
+func testExecAfter(scheduled chan func()) func(time.Duration, func()) *time.Timer {
+	return func(_ time.Duration, f func()) *time.Timer {
+		if scheduled != nil {
+			scheduled <- f
+		}
+		return time.NewTimer(10 * time.Hour) // arbitrary large value for testing
+	}
 }


### PR DESCRIPTION
This implements a fairly simple batching mechanism into the HTTP logger. Batches are written every N milliseconds (kicked off by the first entry of a batch) or if a batch exceeds a defined limit or if it is forced through a call to Flush (which we always do at the end of an activation).