### PR TITLE
Encapsulate remote logging into its own package

### DIFF
--- a/openwhisk/logging/format.go
+++ b/openwhisk/logging/format.go
@@ -1,0 +1,62 @@
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type logtailLogLine struct {
+	Message      string `json:"message,omitempty"`
+	Time         string `json:"dt,omitempty"`
+	Host         string `json:"host,omitempty"`
+	AppName      string `json:"appname,omitempty"`
+	ActivationId string `json:"activationId,omitempty"`
+}
+
+func formatLogtail(l LogLine) ([]byte, error) {
+	return json.Marshal(logtailLogLine{
+		Message:      l.Message,
+		Time:         l.Time.UTC().Format("2006-01-02 15:04:05.000000000 MST"),
+		Host:         l.ActionName,
+		AppName:      l.ActionName,
+		ActivationId: l.ActivationId,
+	})
+}
+
+type datadogLogLine struct {
+	Message string `json:"message,omitempty"`
+	Date    int64  `json:"date,omitempty"`
+	Source  string `json:"ddsource,omitempty"`
+	Service string `json:"service,omitempty"`
+	Tags    string `json:"ddtags,omitempty"`
+}
+
+func formatDatadog(l LogLine) ([]byte, error) {
+	if strings.HasPrefix(l.Message, "{") {
+		var current map[string]interface{}
+		if err := json.Unmarshal([]byte(l.Message), &current); err != nil {
+			// Fall back to a raw line if the JSON can't be parsed.
+			return formatDatadogRaw(l)
+		}
+		current["date"] = l.Time.UnixNano() / int64(time.Millisecond)
+		current["ddsource"] = l.ActionName
+		current["ddtags"] = fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId)
+		current["service"] = l.ActionName
+
+		return json.Marshal(current)
+	}
+
+	return formatDatadogRaw(l)
+}
+
+func formatDatadogRaw(l LogLine) ([]byte, error) {
+	return json.Marshal(datadogLogLine{
+		Message: l.Message,
+		Date:    l.Time.UnixNano() / int64(time.Millisecond),
+		Source:  l.ActionName,
+		Service: l.ActionName,
+		Tags:    fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId),
+	})
+}

--- a/openwhisk/logging/format_test.go
+++ b/openwhisk/logging/format_test.go
@@ -1,0 +1,57 @@
+package logging
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDatadogJSON(t *testing.T) {
+	by, err := formatDatadog(LogLine{
+		Message:      `{"message": "foo", "attribute": "bar"}`,
+		Time:         time.Unix(0, 0),
+		Stream:       "stdout",
+		ActionName:   "testaction",
+		ActivationId: "testid",
+	})
+	assert.NoError(t, err, "failed to format log line")
+
+	var got map[string]interface{}
+	assert.NoError(t, json.Unmarshal(by, &got), "failed to unmarshal log line")
+
+	want := map[string]interface{}{
+		"message":   "foo", // This and 'attribute' are flattened into the structure.
+		"attribute": "bar",
+		"date":      float64(0), // Generic parsing transforms numbers into float64.
+		"ddtags":    "host:testaction,activationid:testid",
+		"ddsource":  "testaction",
+		"service":   "testaction",
+	}
+
+	assert.Equal(t, want, got)
+}
+
+func TestFormatDatadogJSONFallback(t *testing.T) {
+	by, err := formatDatadog(LogLine{
+		Message:      `{ha... i'm not actually JSON :)`,
+		Time:         time.Unix(0, 0),
+		Stream:       "stdout",
+		ActionName:   "testaction",
+		ActivationId: "testid",
+	})
+	assert.NoError(t, err, "failed to format log line")
+
+	var got map[string]interface{}
+	assert.NoError(t, json.Unmarshal(by, &got), "failed to unmarshal log line")
+
+	want := map[string]interface{}{
+		"message":  "{ha... i'm not actually JSON :)", // This and 'attribute' are flattened into the structure.
+		"ddtags":   "host:testaction,activationid:testid",
+		"ddsource": "testaction",
+		"service":  "testaction",
+	}
+
+	assert.Equal(t, want, got)
+}

--- a/openwhisk/logging/logging.go
+++ b/openwhisk/logging/logging.go
@@ -1,11 +1,9 @@
-package openwhisk
+package logging
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 )
@@ -16,60 +14,6 @@ type LogLine struct {
 	Stream       string
 	ActionName   string
 	ActivationId string
-}
-
-type LogtailLogLine struct {
-	Message      string `json:"message,omitempty"`
-	Time         string `json:"dt,omitempty"`
-	Host         string `json:"host,omitempty"`
-	AppName      string `json:"appname,omitempty"`
-	ActivationId string `json:"activationId,omitempty"`
-}
-
-func FormatLogtail(l LogLine) ([]byte, error) {
-	return json.Marshal(LogtailLogLine{
-		Message:      l.Message,
-		Time:         l.Time.UTC().Format("2006-01-02 15:04:05.000000000 MST"),
-		Host:         l.ActionName,
-		AppName:      l.ActionName,
-		ActivationId: l.ActivationId,
-	})
-}
-
-type DatadogLogLine struct {
-	Message string `json:"message,omitempty"`
-	Date    int64  `json:"date,omitempty"`
-	Source  string `json:"ddsource,omitempty"`
-	Service string `json:"service,omitempty"`
-	Tags    string `json:"ddtags,omitempty"`
-}
-
-func FormatDatadog(l LogLine) ([]byte, error) {
-	if strings.HasPrefix(l.Message, "{") {
-		var current map[string]interface{}
-		if err := json.Unmarshal([]byte(l.Message), &current); err != nil {
-			// Fall back to a raw line if the JSON can't be parsed.
-			return formatDatadogRaw(l)
-		}
-		current["date"] = l.Time.UnixNano() / int64(time.Millisecond)
-		current["ddsource"] = l.ActionName
-		current["ddtags"] = fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId)
-		current["service"] = l.ActionName
-
-		return json.Marshal(current)
-	}
-
-	return formatDatadogRaw(l)
-}
-
-func formatDatadogRaw(l LogLine) ([]byte, error) {
-	return json.Marshal(DatadogLogLine{
-		Message: l.Message,
-		Date:    l.Time.UnixNano() / int64(time.Millisecond),
-		Source:  l.ActionName,
-		Service: l.ActionName,
-		Tags:    fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId),
-	})
 }
 
 type RemoteLogger interface {

--- a/openwhisk/logging/setup.go
+++ b/openwhisk/logging/setup.go
@@ -1,0 +1,74 @@
+package logging
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	logDestinationServiceEnv = "LOG_DESTINATION_SERVICE"
+	logtailTokenEnv          = "LOGTAIL_SOURCE_TOKEN"
+	papertrailTokenEnv       = "PAPERTRAIL_TOKEN"
+	datadogSiteEnv           = "DD_SITE"
+	datadogApiKeyEnv         = "DD_API_KEY"
+
+	// This value is somewhat arbitrarily set now. It's low'ish to allow the logs to be written
+	// in parallel to the actual action running to amortize the timing cost of writing the logs
+	// to the backend.
+	logBatchInterval = 100 * time.Millisecond
+	// Datadog limits the size of a batch to 5 MB, so we leave some slack to that.
+	logBatchSizeLimit = 4 * 1024 * 1024
+)
+
+func RemoteLoggerFromEnv(env map[string]string) (RemoteLogger, error) {
+	switch env[logDestinationServiceEnv] {
+	case "logtail":
+		if env[logtailTokenEnv] == "" {
+			return nil, fmt.Errorf("%q has to be an environment variable of the action", logtailTokenEnv)
+		}
+
+		logger := defaultRemoteLogger()
+		logger.url = "https://in.logtail.com"
+		logger.headers = map[string]string{"Authorization": fmt.Sprintf("Bearer %s", env[logtailTokenEnv])}
+		logger.format = formatLogtail
+		logger.batchType = batchTypeArray
+
+		return logger, nil
+	case "papertrail":
+		if env[papertrailTokenEnv] == "" {
+			return nil, fmt.Errorf("%q has to be an environment variable of the action", papertrailTokenEnv)
+		}
+
+		logger := defaultRemoteLogger()
+		logger.url = "https://logs.collector.solarwinds.com/v1/logs"
+		logger.headers = map[string]string{"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(":"+env[papertrailTokenEnv])))}
+		logger.format = formatLogtail // TODO: Is there a better format for papertrail?
+		logger.batchType = batchTypeNewline
+
+		return logger, nil
+	case "datadog":
+		if env[datadogSiteEnv] == "" || env[datadogApiKeyEnv] == "" {
+			return nil, fmt.Errorf("%q and %q have to be an environment variable of the action", datadogSiteEnv, datadogApiKeyEnv)
+		}
+
+		logger := defaultRemoteLogger()
+		logger.url = fmt.Sprintf("https://http-intake.logs.%s/api/v2/logs", env[datadogSiteEnv])
+		logger.headers = map[string]string{"DD-API-KEY": env[datadogApiKeyEnv]}
+		logger.format = formatDatadog
+		logger.batchType = batchTypeArray
+
+		return logger, nil
+	}
+	return nil, nil
+}
+
+func defaultRemoteLogger() *batchingHttpLogger {
+	return &batchingHttpLogger{
+		http:           http.DefaultClient,
+		batchInterval:  logBatchInterval,
+		batchSizeLimit: logBatchSizeLimit,
+		execAfter:      time.AfterFunc,
+	}
+}

--- a/openwhisk/logging/setup_test.go
+++ b/openwhisk/logging/setup_test.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteLoggerSetup(t *testing.T) {
+	tests := []struct {
+		service string
+		env     map[string]string
+	}{{
+		service: "logtail",
+		env: map[string]string{
+			logtailTokenEnv: "testtoken",
+		},
+	}, {
+		service: "papertrail",
+		env: map[string]string{
+			papertrailTokenEnv: "testtoken",
+		},
+	}, {
+		service: "datadog",
+		env: map[string]string{
+			datadogSiteEnv:   "testsite.com",
+			datadogApiKeyEnv: "testtoken",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.service, func(t *testing.T) {
+			test.env["LOG_DESTINATION_SERVICE"] = test.service
+			logger, err := RemoteLoggerFromEnv(test.env)
+			assert.NoError(t, err)
+			assert.NotNil(t, logger)
+		})
+	}
+}
+
+func TestRemoteLoggerSetupNoLogger(t *testing.T) {
+	logger, err := RemoteLoggerFromEnv(map[string]string{})
+	assert.NoError(t, err)
+	assert.Nil(t, logger)
+}
+
+func TestRemoteLoggerFromEnvSetupErrors(t *testing.T) {
+	tests := []struct {
+		service       string
+		wantErrorLine string
+	}{{
+		service:       "logtail",
+		wantErrorLine: `"LOGTAIL_SOURCE_TOKEN" has to be an environment variable of the action`,
+	}, {
+		service:       "papertrail",
+		wantErrorLine: `"PAPERTRAIL_TOKEN" has to be an environment variable of the action`,
+	}, {
+		service:       "datadog",
+		wantErrorLine: `"DD_SITE" and "DD_API_KEY" have to be an environment variable of the action`,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.service, func(t *testing.T) {
+			logger, err := RemoteLoggerFromEnv(map[string]string{"LOG_DESTINATION_SERVICE": test.service})
+			assert.Nil(t, logger)
+			assert.EqualError(t, err, test.wantErrorLine)
+		})
+	}
+}


### PR DESCRIPTION
The logging code got a little unwieldy with it having to support multiple services and stuff. Moving it into its own package so we don't have such a cluttered namespace for types and names. Reduces the surface area of the exported types greatly too.

No behavioural change intended!