### PR TITLE
SERVERLESS-946 Configure remote logger with AP compatible JSON structure

### DIFF
--- a/openwhisk/logging/setup.go
+++ b/openwhisk/logging/setup.go
@@ -86,8 +86,6 @@ func defaultRemoteLogger() *batchingHttpLogger {
 	}
 }
 
-// logDestination implements the same type hierarchy as AP, see
-// https://docs.digitalocean.com/products/app-platform/references/app-specification-reference/#ref-services-log_destinations
 type logDestination struct {
 	Name       string                    `json:"message,omitempty"`
 	Datadog    *logDestinationDatadog    `json:"datadog,omitempty"`
@@ -101,8 +99,6 @@ type logDestinationDatadog struct {
 }
 
 type logDestinationPapertrail struct {
-	// AP uses this but we can't due to not having syslog support (yet).
-	// Endpoint string `json:"endpoint,omitempty"`
 	Token string `json:"token,omitempty"`
 }
 

--- a/openwhisk/logging/setup.go
+++ b/openwhisk/logging/setup.go
@@ -2,17 +2,15 @@ package logging
 
 import (
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 )
 
 const (
-	logDestinationServiceEnv = "LOG_DESTINATION_SERVICE"
-	logtailTokenEnv          = "LOGTAIL_SOURCE_TOKEN"
-	papertrailTokenEnv       = "PAPERTRAIL_TOKEN"
-	datadogSiteEnv           = "DD_SITE"
-	datadogApiKeyEnv         = "DD_API_KEY"
+	logDestinationsEnv = "LOG_DESTINATIONS"
 
 	// This value is somewhat arbitrarily set now. It's low'ish to allow the logs to be written
 	// in parallel to the actual action running to amortize the timing cost of writing the logs
@@ -23,45 +21,60 @@ const (
 )
 
 func RemoteLoggerFromEnv(env map[string]string) (RemoteLogger, error) {
-	switch env[logDestinationServiceEnv] {
-	case "logtail":
-		if env[logtailTokenEnv] == "" {
-			return nil, fmt.Errorf("%q has to be an environment variable of the action", logtailTokenEnv)
+	if env[logDestinationsEnv] == "" {
+		return nil, nil
+	}
+
+	var logDestinations []logDestination
+	if err := json.Unmarshal([]byte(env[logDestinationsEnv]), &logDestinations); err != nil {
+		return nil, fmt.Errorf("failed to parse %q into valid log destinations: %w", logDestinationsEnv, err)
+	}
+
+	if len(logDestinations) == 0 {
+		return nil, nil
+	}
+
+	// TODO(SERVERLESS-958): Actually support multiple endpoints.
+	d := logDestinations[0]
+	if d.Logtail != nil {
+		if d.Logtail.Token == "" {
+			return nil, errors.New("logtail.token has to be defined")
 		}
 
 		logger := defaultRemoteLogger()
 		logger.url = "https://in.logtail.com"
-		logger.headers = map[string]string{"Authorization": fmt.Sprintf("Bearer %s", env[logtailTokenEnv])}
+		logger.headers = map[string]string{"Authorization": fmt.Sprintf("Bearer %s", d.Logtail.Token)}
 		logger.format = formatLogtail
 		logger.batchType = batchTypeArray
 
 		return logger, nil
-	case "papertrail":
-		if env[papertrailTokenEnv] == "" {
-			return nil, fmt.Errorf("%q has to be an environment variable of the action", papertrailTokenEnv)
+	} else if d.Papertrail != nil {
+		if d.Papertrail.Token == "" {
+			return nil, errors.New("papertrail.token has to be defined")
 		}
 
 		logger := defaultRemoteLogger()
 		logger.url = "https://logs.collector.solarwinds.com/v1/logs"
-		logger.headers = map[string]string{"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(":"+env[papertrailTokenEnv])))}
+		logger.headers = map[string]string{"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(":"+d.Papertrail.Token)))}
 		logger.format = formatLogtail // TODO: Is there a better format for papertrail?
 		logger.batchType = batchTypeNewline
 
 		return logger, nil
-	case "datadog":
-		if env[datadogSiteEnv] == "" || env[datadogApiKeyEnv] == "" {
-			return nil, fmt.Errorf("%q and %q have to be an environment variable of the action", datadogSiteEnv, datadogApiKeyEnv)
+	} else if d.Datadog != nil {
+		if d.Datadog.ApiKey == "" || d.Datadog.Endpoint == "" {
+			return nil, errors.New("datadog.endpoint and datadog.api_key have to be defined")
 		}
 
 		logger := defaultRemoteLogger()
-		logger.url = fmt.Sprintf("https://http-intake.logs.%s/api/v2/logs", env[datadogSiteEnv])
-		logger.headers = map[string]string{"DD-API-KEY": env[datadogApiKeyEnv]}
+		logger.url = fmt.Sprintf("%s/api/v2/logs", d.Datadog.Endpoint)
+		logger.headers = map[string]string{"DD-API-KEY": d.Datadog.ApiKey}
 		logger.format = formatDatadog
 		logger.batchType = batchTypeArray
 
 		return logger, nil
+	} else {
+		return nil, fmt.Errorf("invalid log destinations value in %q: either logtail, papertrail or datadog must be set", logDestinationsEnv)
 	}
-	return nil, nil
 }
 
 func defaultRemoteLogger() *batchingHttpLogger {
@@ -71,4 +84,27 @@ func defaultRemoteLogger() *batchingHttpLogger {
 		batchSizeLimit: logBatchSizeLimit,
 		execAfter:      time.AfterFunc,
 	}
+}
+
+// logDestination implements the same type hierarchy as AP, see
+// https://docs.digitalocean.com/products/app-platform/references/app-specification-reference/#ref-services-log_destinations
+type logDestination struct {
+	Name       string                    `json:"message,omitempty"`
+	Datadog    *logDestinationDatadog    `json:"datadog,omitempty"`
+	Papertrail *logDestinationPapertrail `json:"papertrail,omitempty"`
+	Logtail    *logDestinationLogtail    `json:"logtail,omitempty"`
+}
+
+type logDestinationDatadog struct {
+	Endpoint string `json:"endpoint,omitempty"`
+	ApiKey   string `json:"api_key,omitempty"`
+}
+
+type logDestinationPapertrail struct {
+	// Endpoint string `json:"endpoint,omitempty"` // AP uses this but we can't due to not having syslog support (yet).
+	Token string `json:"token,omitempty"`
+}
+
+type logDestinationLogtail struct {
+	Token string `json:"token,omitempty"`
 }

--- a/openwhisk/logging/setup.go
+++ b/openwhisk/logging/setup.go
@@ -101,7 +101,8 @@ type logDestinationDatadog struct {
 }
 
 type logDestinationPapertrail struct {
-	// Endpoint string `json:"endpoint,omitempty"` // AP uses this but we can't due to not having syslog support (yet).
+	// AP uses this but we can't due to not having syslog support (yet).
+	// Endpoint string `json:"endpoint,omitempty"`
 	Token string `json:"token,omitempty"`
 }
 


### PR DESCRIPTION
This builds on #11, which should be reviewed and dealt with first.

---

Instead of relying on individual environment variables, we want to pass a single LOG_DESTINATIONS environment variable, containing the JSON-marshalled version of the log_destinations array of an AppSpec. This implements the respective type hierarchy and connects the pieces.