### PR TITLE
SERVERLESS-958 Support multiple log destinations at once

### DIFF
--- a/openwhisk/logging/setup_test.go
+++ b/openwhisk/logging/setup_test.go
@@ -8,30 +8,46 @@ import (
 
 func TestRemoteLoggerSetup(t *testing.T) {
 	tests := []struct {
-		name string
-		env  map[string]string
+		name        string
+		env         map[string]string
+		wantLoggers int
 	}{{
 		name: "logtail",
 		env: map[string]string{
 			logDestinationsEnv: `[{"name": "foo", "logtail": {"token": "testtoken"}}]`,
 		},
+		wantLoggers: 1,
 	}, {
 		name: "papertrail",
 		env: map[string]string{
 			logDestinationsEnv: `[{"name": "foo", "papertrail": {"token": "testtoken"}}]`,
 		},
+		wantLoggers: 1,
 	}, {
 		name: "datadog",
 		env: map[string]string{
 			logDestinationsEnv: `[{"name": "foo", "datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}]`,
 		},
+		wantLoggers: 1,
+	}, {
+		name: "two datadogs",
+		env: map[string]string{
+			logDestinationsEnv: `[{"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}, {"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}]`,
+		},
+		wantLoggers: 2,
+	}, {
+		name: "one of each",
+		env: map[string]string{
+			logDestinationsEnv: `[{"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}, {"papertrail": {"token": "testtoken"}}, {"logtail": {"token": "testtoken"}}]`,
+		},
+		wantLoggers: 3,
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			logger, err := RemoteLoggerFromEnv(test.env)
+			loggers, err := RemoteLoggerFromEnv(test.env)
 			assert.NoError(t, err)
-			assert.NotNil(t, logger)
+			assert.Len(t, loggers, test.wantLoggers)
 		})
 	}
 }


### PR DESCRIPTION
This implements parity with APs ability to configure more than one log destination for a component. I specifically opted to not do the requests in parallel (yet) as it'd add quite a bit of complexity (handling errors, ideally pre-launching a pool of goroutines rather than launching one per request etc.) that I'd like to discuss separately. I'd also like to check how common that case even is and if it warrants the extra complexity.