### PR TITLE
Distinguish output/error management in compile script by context

### DIFF
--- a/common/defaultBuild
+++ b/common/defaultBuild
@@ -20,7 +20,7 @@
 #
 
 # This performs the default build action of this runtime when executed in an action build directory
+set -e
+export __NIM_REMOTE_BUILD=true
 $OW_COMPILER Main . .
 echo exec > .include
-
-

--- a/golang1.15/bin/compile
+++ b/golang1.15/bin/compile
@@ -83,25 +83,43 @@ def build(source_dir, target_dir):
     }
 
     gomod = "%s/go.mod" % source_dir
-    with open(os.devnull, "w") as dn:
+    if os.environ.get("__NIM_REMOTE_BUILD"):
         if exists(gomod):
-            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+            print("downloading modules")
+            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
             if ret != 0:
-                print("cannot download modules")
-                return
+                sys.exit(ret)
         else:
-            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+            print("initializing modules")
+            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
             if ret != 0:
-                print("cannot init modules")
-                return
+                sys.exit(ret)
+    else:
+        with open(os.devnull, "w") as dn:
+            if exists(gomod):
+                ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+                if ret != 0:
+                    print("cannot download modules")
+                    return
+            else:
+                ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+                if ret != 0:
+                    print("cannot init modules")
+                    return
 
     ldflags = "-s -w"
     gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
     if os.environ.get("__OW_EXECUTION_ENV"):
         ldflags += " -X main.OwExecutionEnv=%s" % os.environ["__OW_EXECUTION_ENV"]
-    ret = subprocess.call(gobuild, cwd=source_dir, env=env)
-    if ret != 0:
-        print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
+    if os.environ.get("__NIM_REMOTE_BUILD"):
+        print("building")
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            sys.exit(ret)
+    else:
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
 
 def debug(source_dir, target_dir, port):
     source_dir = os.path.abspath(source_dir)

--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -83,25 +83,43 @@ def build(source_dir, target_dir):
     }
 
     gomod = "%s/go.mod" % source_dir
-    with open(os.devnull, "w") as dn:
+    if os.environ.get("__NIM_REMOTE_BUILD"):
         if exists(gomod):
-            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+            print("downloading modules")
+            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
             if ret != 0:
-                print("cannot download modules")
-                return
+                sys.exit(ret)
         else:
-            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+            print("initializing modules")
+            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
             if ret != 0:
-                print("cannot init modules")
-                return
+                sys.exit(ret)
+    else:
+        with open(os.devnull, "w") as dn:
+            if exists(gomod):
+                ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+                if ret != 0:
+                    print("cannot download modules")
+                    return
+            else:
+                ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+                if ret != 0:
+                    print("cannot init modules")
+                    return
 
     ldflags = "-s -w"
     gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
     if os.environ.get("__OW_EXECUTION_ENV"):
         ldflags += " -X main.OwExecutionEnv=%s" % os.environ["__OW_EXECUTION_ENV"]
-    ret = subprocess.call(gobuild, cwd=source_dir, env=env)
-    if ret != 0:
-        print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
+    if os.environ.get("__NIM_REMOTE_BUILD"):
+        print("building")
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            sys.exit(ret)
+    else:
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
 
 def debug(source_dir, target_dir, port):
     source_dir = os.path.abspath(source_dir)


### PR DESCRIPTION
If running under go proxy in compile-on-demand action loop, the upstream logic should govern.  If running under `defaultBuild` under `nim`, all output should be available and any error should cause non-zero exit.

Also ensures that `defaultBuild` runs with `set -e` so that failure of the compile script is propagated up the call chain.