### PR TITLE
SERVERLESS-1103 Use more context information from AP, if provided

### DIFF
--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -46,7 +46,6 @@ var DefaultTimeoutStart = 5 * time.Millisecond
 
 type activationMetadata struct {
 	ActivationId string `json:"activation_id"`
-	ActionName   string `json:"action_name"`
 }
 
 // Executor is the container and the guardian  of a child process
@@ -186,7 +185,6 @@ func (proc *Executor) Interact(in []byte) ([]byte, error) {
 			}
 
 			line.ActivationId = metadata.ActivationId
-			line.ActionName = metadata.ActionName
 
 			// TODO: We probably want to do this in parallel. Opting for a simple implementation
 			// first to close the loop. We might also want to check how common multiple loggers

--- a/openwhisk/executor_test.go
+++ b/openwhisk/executor_test.go
@@ -182,12 +182,10 @@ func TestExecutorRemoteLogging(t *testing.T) {
 	want := []logging.LogLine{{
 		Stream:       "stdout",
 		Message:      "hello from stdout",
-		ActionName:   "testaction",
 		ActivationId: "testid",
 	}, {
 		Stream:       "stderr",
 		Message:      "hello from stderr",
-		ActionName:   "testaction",
 		ActivationId: "testid",
 	}}
 

--- a/openwhisk/logging/format.go
+++ b/openwhisk/logging/format.go
@@ -15,14 +15,16 @@ type logtailLogLine struct {
 	ActivationId string `json:"activationId,omitempty"`
 }
 
-func formatLogtail(l LogLine) ([]byte, error) {
-	return json.Marshal(logtailLogLine{
-		Message:      l.Message,
-		Time:         l.Time.UTC().Format("2006-01-02 15:04:05.000000000 MST"),
-		Host:         l.ActionName,
-		AppName:      l.ActionName,
-		ActivationId: l.ActivationId,
-	})
+func formatLogtail(metadata logDestinationAttributes) func(LogLine) ([]byte, error) {
+	return func(l LogLine) ([]byte, error) {
+		return json.Marshal(logtailLogLine{
+			Message:      l.Message,
+			Time:         l.Time.UTC().Format("2006-01-02 15:04:05.000000000 MST"),
+			Host:         metadata.AppName,
+			AppName:      metadata.ComponentName,
+			ActivationId: l.ActivationId,
+		})
+	}
 }
 
 type datadogLogLine struct {
@@ -33,30 +35,32 @@ type datadogLogLine struct {
 	Tags    string `json:"ddtags,omitempty"`
 }
 
-func formatDatadog(l LogLine) ([]byte, error) {
-	if strings.HasPrefix(l.Message, "{") {
-		var current map[string]interface{}
-		if err := json.Unmarshal([]byte(l.Message), &current); err != nil {
-			// Fall back to a raw line if the JSON can't be parsed.
-			return formatDatadogRaw(l)
+func formatDatadog(metadata logDestinationAttributes) func(LogLine) ([]byte, error) {
+	return func(l LogLine) ([]byte, error) {
+		if strings.HasPrefix(l.Message, "{") {
+			var current map[string]interface{}
+			if err := json.Unmarshal([]byte(l.Message), &current); err != nil {
+				// Fall back to a raw line if the JSON can't be parsed.
+				return formatDatadogRaw(metadata, l)
+			}
+			current["date"] = l.Time.UnixNano() / int64(time.Millisecond)
+			current["ddsource"] = metadata.AppName
+			current["ddtags"] = fmt.Sprintf("host:%s,activationid:%s", metadata.AppName, l.ActivationId)
+			current["service"] = metadata.ComponentName
+
+			return json.Marshal(current)
 		}
-		current["date"] = l.Time.UnixNano() / int64(time.Millisecond)
-		current["ddsource"] = l.ActionName
-		current["ddtags"] = fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId)
-		current["service"] = l.ActionName
 
-		return json.Marshal(current)
+		return formatDatadogRaw(metadata, l)
 	}
-
-	return formatDatadogRaw(l)
 }
 
-func formatDatadogRaw(l LogLine) ([]byte, error) {
+func formatDatadogRaw(metadata logDestinationAttributes, l LogLine) ([]byte, error) {
 	return json.Marshal(datadogLogLine{
 		Message: l.Message,
 		Date:    l.Time.UnixNano() / int64(time.Millisecond),
-		Source:  l.ActionName,
-		Service: l.ActionName,
-		Tags:    fmt.Sprintf("host:%s,activationid:%s", l.ActionName, l.ActivationId),
+		Source:  metadata.AppName,
+		Service: metadata.ComponentName,
+		Tags:    fmt.Sprintf("host:%s,activationid:%s", metadata.AppName, l.ActivationId),
 	})
 }

--- a/openwhisk/logging/format_test.go
+++ b/openwhisk/logging/format_test.go
@@ -9,11 +9,10 @@ import (
 )
 
 func TestFormatDatadogJSON(t *testing.T) {
-	by, err := formatDatadog(LogLine{
+	by, err := formatDatadog(logDestinationAttributes{"testapp", "testfunct"})(LogLine{
 		Message:      `{"message": "foo", "attribute": "bar"}`,
 		Time:         time.Unix(0, 0),
 		Stream:       "stdout",
-		ActionName:   "testaction",
 		ActivationId: "testid",
 	})
 	assert.NoError(t, err, "failed to format log line")
@@ -25,20 +24,19 @@ func TestFormatDatadogJSON(t *testing.T) {
 		"message":   "foo", // This and 'attribute' are flattened into the structure.
 		"attribute": "bar",
 		"date":      float64(0), // Generic parsing transforms numbers into float64.
-		"ddtags":    "host:testaction,activationid:testid",
-		"ddsource":  "testaction",
-		"service":   "testaction",
+		"ddtags":    "host:testapp,activationid:testid",
+		"ddsource":  "testapp",
+		"service":   "testfunct",
 	}
 
 	assert.Equal(t, want, got)
 }
 
 func TestFormatDatadogJSONFallback(t *testing.T) {
-	by, err := formatDatadog(LogLine{
+	by, err := formatDatadog(logDestinationAttributes{"testapp", "testfunct"})(LogLine{
 		Message:      `{ha... i'm not actually JSON :)`,
 		Time:         time.Unix(0, 0),
 		Stream:       "stdout",
-		ActionName:   "testaction",
 		ActivationId: "testid",
 	})
 	assert.NoError(t, err, "failed to format log line")
@@ -48,9 +46,9 @@ func TestFormatDatadogJSONFallback(t *testing.T) {
 
 	want := map[string]interface{}{
 		"message":  "{ha... i'm not actually JSON :)", // This and 'attribute' are flattened into the structure.
-		"ddtags":   "host:testaction,activationid:testid",
-		"ddsource": "testaction",
-		"service":  "testaction",
+		"ddtags":   "host:testapp,activationid:testid",
+		"ddsource": "testapp",
+		"service":  "testfunct",
 	}
 
 	assert.Equal(t, want, got)

--- a/openwhisk/logging/logging.go
+++ b/openwhisk/logging/logging.go
@@ -12,7 +12,6 @@ type LogLine struct {
 	Message      string
 	Time         time.Time
 	Stream       string
-	ActionName   string
 	ActivationId string
 }
 

--- a/openwhisk/logging/setup.go
+++ b/openwhisk/logging/setup.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
 const (
 	logDestinationsEnv = "LOG_DESTINATIONS"
+	actionNameEnv      = "__OW_ACTION_NAME"
 
 	// This value is somewhat arbitrarily set now. It's low'ish to allow the logs to be written
 	// in parallel to the actual action running to amortize the timing cost of writing the logs
@@ -24,10 +26,29 @@ func RemoteLoggerFromEnv(env map[string]string) ([]RemoteLogger, error) {
 	if env[logDestinationsEnv] == "" {
 		return nil, nil
 	}
-
+	valueToParse := env[logDestinationsEnv]
 	var logDestinations []logDestination
-	if err := json.Unmarshal([]byte(env[logDestinationsEnv]), &logDestinations); err != nil {
-		return nil, fmt.Errorf("failed to parse %q into valid log destinations: %w", logDestinationsEnv, err)
+	var logAttributes logDestinationAttributes
+	if strings.HasPrefix(valueToParse, "[") {
+		// It's an array, the "smaller" format of just using the log destinations applies.
+		if err := json.Unmarshal([]byte(valueToParse), &logDestinations); err != nil {
+			return nil, fmt.Errorf("failed to parse %q into valid log destinations: %w", logDestinationsEnv, err)
+		}
+
+		// Fall back to all action name attributes if no other attributes are passed.
+		actionName := env[actionNameEnv]
+		logAttributes = logDestinationAttributes{
+			AppName:       actionName,
+			ComponentName: actionName,
+		}
+	} else {
+		// The "richer" format, containing more metadata, applies.
+		var logDestinationConfig logDestinationConfig
+		if err := json.Unmarshal([]byte(env[logDestinationsEnv]), &logDestinationConfig); err != nil {
+			return nil, fmt.Errorf("failed to parse %q into valid log destinations: %w", logDestinationsEnv, err)
+		}
+		logDestinations = logDestinationConfig.Destinations
+		logAttributes = logDestinationConfig.Attributes
 	}
 
 	if len(logDestinations) == 0 {
@@ -44,7 +65,7 @@ func RemoteLoggerFromEnv(env map[string]string) ([]RemoteLogger, error) {
 			logger := defaultRemoteLogger()
 			logger.url = "https://in.logtail.com"
 			logger.headers = map[string]string{"Authorization": fmt.Sprintf("Bearer %s", d.Logtail.Token)}
-			logger.format = formatLogtail
+			logger.format = formatLogtail(logAttributes)
 			logger.batchType = batchTypeArray
 
 			loggers = append(loggers, logger)
@@ -56,7 +77,7 @@ func RemoteLoggerFromEnv(env map[string]string) ([]RemoteLogger, error) {
 			logger := defaultRemoteLogger()
 			logger.url = "https://logs.collector.solarwinds.com/v1/logs"
 			logger.headers = map[string]string{"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(":"+d.Papertrail.Token)))}
-			logger.format = formatLogtail // TODO: Is there a better format for papertrail?
+			logger.format = formatLogtail(logAttributes) // TODO: Is there a better format for papertrail?
 			logger.batchType = batchTypeNewline
 
 			loggers = append(loggers, logger)
@@ -68,7 +89,7 @@ func RemoteLoggerFromEnv(env map[string]string) ([]RemoteLogger, error) {
 			logger := defaultRemoteLogger()
 			logger.url = fmt.Sprintf("%s/api/v2/logs", d.Datadog.Endpoint)
 			logger.headers = map[string]string{"DD-API-KEY": d.Datadog.ApiKey}
-			logger.format = formatDatadog
+			logger.format = formatDatadog(logAttributes)
 			logger.batchType = batchTypeArray
 
 			loggers = append(loggers, logger)
@@ -86,6 +107,16 @@ func defaultRemoteLogger() *batchingHttpLogger {
 		batchSizeLimit: logBatchSizeLimit,
 		execAfter:      time.AfterFunc,
 	}
+}
+
+type logDestinationConfig struct {
+	Destinations []logDestination         `json:"destinations,omitempty"`
+	Attributes   logDestinationAttributes `json:"attributes,omitempty"`
+}
+
+type logDestinationAttributes struct {
+	AppName       string `json:"app_name,omitempty"`
+	ComponentName string `json:"component_name,omitempty"`
 }
 
 type logDestination struct {

--- a/openwhisk/logging/setup_test.go
+++ b/openwhisk/logging/setup_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,12 @@ func TestRemoteLoggerSetup(t *testing.T) {
 			logDestinationsEnv: `[{"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}, {"papertrail": {"token": "testtoken"}}, {"logtail": {"token": "testtoken"}}]`,
 		},
 		wantLoggers: 3,
+	}, {
+		name: "more information format",
+		env: map[string]string{
+			logDestinationsEnv: `{"destinations":[{"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}], "attributes":{"app_name": "foo", "component_name": "bar"}}`,
+		},
+		wantLoggers: 1,
 	}}
 
 	for _, test := range tests {
@@ -80,9 +87,9 @@ func TestRemoteLoggerFromEnvSetupErrors(t *testing.T) {
 	}, {
 		name: "borked",
 		env: map[string]string{
-			logDestinationsEnv: `{}`,
+			logDestinationsEnv: `{.`,
 		},
-		wantErrorLine: `failed to parse "LOG_DESTINATIONS" into valid log destinations: json: cannot unmarshal object into Go value of type []logging.logDestination`,
+		wantErrorLine: `failed to parse "LOG_DESTINATIONS" into valid log destinations: invalid character '.' looking for beginning of object key string`,
 	}, {
 		name: "logtail",
 		env: map[string]string{
@@ -108,6 +115,49 @@ func TestRemoteLoggerFromEnvSetupErrors(t *testing.T) {
 			logger, err := RemoteLoggerFromEnv(test.env)
 			assert.Nil(t, logger)
 			assert.EqualError(t, err, test.wantErrorLine)
+		})
+	}
+}
+
+func TestRemoteLoggerFromEnvCorrectMetadata(t *testing.T) {
+	tests := []struct {
+		name              string
+		env               map[string]string
+		wantAppName       string
+		wantComponentName string
+	}{{
+		name: "new format",
+		env: map[string]string{
+			actionNameEnv:      "/ns/pkg/testaction",
+			logDestinationsEnv: `{"destinations":[{"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}], "attributes":{"app_name": "foo", "component_name": "bar"}}`,
+		},
+		wantAppName:       "foo",
+		wantComponentName: "bar",
+	}, {
+		name: "old format",
+		env: map[string]string{
+			actionNameEnv:      "/ns/pkg/testaction",
+			logDestinationsEnv: `[{"datadog": {"endpoint": "testendpoint", "api_key": "testkey"}}]`,
+		},
+		wantAppName:       "/ns/pkg/testaction",
+		wantComponentName: "/ns/pkg/testaction",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, err := RemoteLoggerFromEnv(test.env)
+			assert.NoError(t, err)
+			assert.Len(t, logger, 1)
+
+			b, err := logger[0].(*batchingHttpLogger).format(LogLine{})
+			assert.NoError(t, err)
+
+			var line datadogLogLine
+			err = json.Unmarshal(b, &line)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.wantAppName, line.Source)
+			assert.Equal(t, test.wantComponentName, line.Service)
 		})
 	}
 }


### PR DESCRIPTION
When running inside AP, there's more context we might want to log to more closely match their experience.

This keeps compatibility with the "old" format, which was a JSON array of log destinations without any additional metadata. This makes it more convenient to provide log destinations yourself if you don't care about the additional metadata.