### PR TITLE
Stop blindly capitalizing 'main'

### DIFF
--- a/golang1.15/bin/compile
+++ b/golang1.15/bin/compile
@@ -41,7 +41,10 @@ def copy_replace(src, dst, match=None, replacement=""):
 
 
 def sources(launcher, source_dir, main):
-    func = main.capitalize()
+    func = main
+    if func == "main":
+        # main is defaulted to "main" in the go-proxy. We want to fix that here.
+        func = "Main"
     has_main = None
 
     # copy the exec to exec.go

--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -41,7 +41,10 @@ def copy_replace(src, dst, match=None, replacement=""):
 
 
 def sources(launcher, source_dir, main):
-    func = main.capitalize()
+    func = main
+    if func == "main":
+        # main is defaulted to "main" in the go-proxy. We want to fix that here.
+        func = "Main"
     has_main = None
 
     # copy the exec to exec.go

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGoTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGoTests.scala
@@ -125,7 +125,7 @@ abstract class ActionLoopBasicGoTests
        | return args
        |}
     """.stripMargin,
-    main = "niam"
+    main = "Niam"
   )
 
   override val testLargeInput = TestConfig(

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopGoContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopGoContainerTests.scala
@@ -38,7 +38,7 @@ abstract class ActionLoopGoContainerTests
   behavior of image
 
   def helloGo(main: String, pkg: String = "main") = {
-    val func = main.capitalize
+    val func = if(main == "main") "Main" else main
     s"""|package ${pkg}
         |
         |import "fmt"


### PR DESCRIPTION
'main' defines which function the Golang runtime executes on an invocation. The go-proxy defaults 'main' to "main", which usually doesn't work for Golang functions, since that'd collide with the "special" main function in Golang. So we called 'capitalize' to fix that (it turns "main" into "Main").

However, it destroys all kinds of other usages. If one defines "WebAction", it'll transform that into "Webaction", which is wrong.

As such, we want to only specifically fix the main -> Main conversion and leave the parameter alone for all other cases.