### PR TITLE
Correctly return error from a function's execution

### DIFF
--- a/golang1.17/lib/launcher.go
+++ b/golang1.17/lib/launcher.go
@@ -87,8 +87,7 @@ func main() {
 		}
 		output, err := execute(Main, inbuf)
 		if err != nil {
-			fmt.Fprintf(out, `{"error":%q}`, err.Error())
-			continue
+			output = []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
 		}
 		if debug {
 			log.Printf("<<<'%s'<<<", output)


### PR DESCRIPTION
If an error happened not in the action itself but in it's proximity (i.e. during unmarshalling of the JSON), we didn't properly return the error, because there was no newline printed after the error, which is needed to advance the reader in the go-proxy.

This fixes that and also feeds the error return back into a more "usual" flow to also make sure we print it on debug and we print the sentinels as well.