### PR TITLE
'main' is now an optional arg to defaultBuild

### DIFF
--- a/common/defaultBuild
+++ b/common/defaultBuild
@@ -21,6 +21,7 @@
 
 # This performs the default build action of this runtime when executed in an action build directory
 set -e
+MAIN=${1:-Main}
 export __NIM_REMOTE_BUILD=true
-$OW_COMPILER Main . .
+$OW_COMPILER $MAIN . .
 echo exec > .include


### PR DESCRIPTION
This change works in tandem with a change to default build generation in `nim`.  Instead of hard-coding the name of the Main function to `Main` (the action-loop default) the `defaultBuild` script can now accept an optional first argument which will change that to a developer-chosen name.