### PR TITLE
Catch panics and transform them into error returns

### DIFF
--- a/golang1.17/lib/launcher.go
+++ b/golang1.17/lib/launcher.go
@@ -172,7 +172,15 @@ func validate(f interface{}) error {
 //
 // All permutations of the signatures defined in buildArguments and handleReturnValues
 // are supported.
-func invoke(ctx context.Context, f interface{}, in []byte) ([]byte, error) {
+func invoke(ctx context.Context, f interface{}, in []byte) (out []byte, err error) {
+	defer func() {
+		// Transform a panic into an error response.
+		if p := recover(); p != nil {
+			err := fmt.Errorf("function panicked: %v", p)
+			out = []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
+		}
+	}()
+
 	fun := reflect.ValueOf(f)
 
 	arguments, err := buildArguments(ctx, fun, in)

--- a/golang1.17/lib/launcher_test.go
+++ b/golang1.17/lib/launcher_test.go
@@ -187,6 +187,12 @@ func TestInvoke(t *testing.T) {
 			return TestTypeOut{Bar: in.Foo}, assert.AnError
 		},
 		want: wantError,
+	}, {
+		name: "panick: return error",
+		f: func() {
+			panic("test")
+		},
+		want: []byte(`{"error":"function panicked: test"}`),
 	}}
 
 	for _, tt := range tests {

--- a/golang1.17/lib/launcher_test.go
+++ b/golang1.17/lib/launcher_test.go
@@ -188,7 +188,7 @@ func TestInvoke(t *testing.T) {
 		},
 		want: wantError,
 	}, {
-		name: "panick: return error",
+		name: "panic: return error",
 		f: func() {
 			panic("test")
 		},


### PR DESCRIPTION
This might be a little controversial because it can be argued that users might want their entire state eradicated if their action panics. However, right now, a panic causes a full-on container recreation which might be excessive. This catches panics and transforms them into "normal" error returns.