### PR TITLE
SERVERLESS-1376 Allow prelaunching binaries on startup

### DIFF
--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -179,6 +179,17 @@ func (ap *ActionProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Start creates a proxy to execute actions
 func (ap *ActionProxy) Start(port int) {
+	// Prelaunch a binary if wanted.
+	prestartExecutable := os.Getenv("OW_INIT_IN_ACTIONLOOP")
+	if prestartExecutable != "" {
+		// Propagate the basic environment now to make sure it makes its way into the process.
+		ap.SetEnv(nil)
+		ap.theExecutor = NewExecutor(ap.outFile, ap.errFile, prestartExecutable, ap.env)
+		if err := ap.theExecutor.Start(true); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	// listen and start
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), ap))
 }


### PR DESCRIPTION
This adds a new mode to the go-proxy which allows it to launch a child binary on startup to amortize the cost of doing so. In that mode, which is triggered by the presence of an environment variable, the child process is expected to be able to deal with initialization itself. As such, it's passed the raw init request and is expected to respond with the "usual" OK response.

**Note:** Scala tests are 🟢 