### PR TITLE
Fix Go 1.17 build failure

### DIFF
--- a/golang1.17/Dockerfile
+++ b/golang1.17/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
      librdkafka-dev=0.11.6-1.1 &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go get -u github.com/go-delve/delve/cmd/dlv &&\
+    go install github.com/go-delve/delve/cmd/dlv &&\
     mkdir /action
 
 ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh

--- a/golang1.17/Dockerfile
+++ b/golang1.17/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
      librdkafka-dev=0.11.6-1.1 &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go install github.com/go-delve/delve/cmd/dlv &&\
+    go install github.com/go-delve/delve/cmd/dlv@v1.9.0 &&\
     mkdir /action
 
 ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh


### PR DESCRIPTION
The `build-runtimes` job is failing while attempting to build the Go 1.17 runtime:

> #5 24.93 go get: installing executables with 'go get' in module mode is deprecated.
> #5 24.93 	Use 'go install pkg@version' instead.
> #5 24.93 	For more information, see https://golang.org/doc/go-get-install-deprecation
> #5 24.93 	or run 'go help get' or 'go help install'.
> #5 25.08 # github.com/rivo/uniseg
> #5 25.08 pkg/mod/github.com/rivo/uniseg@v0.3.1/properties.go:130:6: missing function body
> #5 25.08 pkg/mod/github.com/rivo/uniseg@v0.3.1/properties.go:130:20: syntax error: unexpected [, expecting (
> #5 25.08 note: module requires Go 1.18

This PR replaces `go get` with `go install`. Note that we have to explicitly specify the version of `delve` (1.9.0) to install because there is no direct dependency for that package in the `go.mod` file.