### PR TITLE
Remove the nim install

### DIFF
--- a/golang1.15/Dockerfile
+++ b/golang1.15/Dockerfile
@@ -40,11 +40,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
     go get -u github.com/go-delve/delve/cmd/dlv &&\
     mkdir /action
 
-# retain nim install during transition to functions-deployer
-ARG NIM_INSTALL_SCRIPT
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl ${NIM_INSTALL_SCRIPT} | bash
-# install the functions-deployer (co-exist with nim temporarily)
+# install the functions-deployer
 ARG DEPLOYER_DOWNLOAD
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \

--- a/golang1.17/Dockerfile
+++ b/golang1.17/Dockerfile
@@ -40,11 +40,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
     go install github.com/go-delve/delve/cmd/dlv@v1.9.0 &&\
     mkdir /action
 
-# retain nim install during transition to functions-deployer
-ARG NIM_INSTALL_SCRIPT
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl ${NIM_INSTALL_SCRIPT} | bash
-# install the functions-deployer (co-exist with nim temporarily)
+# install the functions-deployer
 ARG DEPLOYER_DOWNLOAD
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \


### PR DESCRIPTION
We previously added an install for the DigitalOcean functions deployer.   The builder actions have been revised to invoke it instead of `nim`.  This PR completes the switch-over by removing `nim`.