### PR TITLE
SERVERLESS-2296 | Support private dependencies in Go functions by supporting vendoring

### DIFF
--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -92,7 +92,7 @@ def build(source_dir, target_dir):
     deps_vendored = exists(vendor)
 
     if has_gomod:
-        print("detected go.mod file")
+        print("Detected go.mod file.")
     if deps_vendored:
         print("Detected vendor directory. Will skip downloading modules.")
 

--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -97,8 +97,7 @@ def build(source_dir, target_dir):
         print("Detected vendor directory. Will skip downloading and initialization modules.")
 
     if os.environ.get("__NIM_REMOTE_BUILD"):
-        if has_gomod:
-            if not deps_vendored:
+        if has_gomod and not deps_vendored:
                 print("downloading modules")
                 ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
                 if ret != 0:

--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -94,27 +94,28 @@ def build(source_dir, target_dir):
     if has_gomod:
         print("detected go.mod file")
     if deps_vendored:
-        print("Detected vendor directory. Will skip downloading and initialization modules.")
+        print("Detected vendor directory. Will skip downloading modules.")
 
     if os.environ.get("__NIM_REMOTE_BUILD"):
-        if has_gomod and not deps_vendored:
+        if has_gomod:
+            if not deps_vendored:
                 print("downloading modules")
                 ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
                 if ret != 0:
                     sys.exit(ret)
         else:
-            if not deps_vendored:
-                print("initializing modules")
-                ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
-                if ret != 0:
-                    sys.exit(ret)
+            print("initializing modules")
+            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
+            if ret != 0:
+                sys.exit(ret)
     else:
         with open(os.devnull, "w") as dn:
             if has_gomod:
-                ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
-                if ret != 0:
-                    print("cannot download modules")
-                    return
+                if not deps_vendored:
+                    ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+                    if ret != 0:
+                        print("cannot download modules")
+                        return
             else:
                 ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
                 if ret != 0:

--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -86,20 +86,32 @@ def build(source_dir, target_dir):
     }
 
     gomod = "%s/go.mod" % source_dir
+    vendor = "%s/vendor" % source_dir
+
+    has_gomod = exists(gomod)
+    deps_vendored = exists(vendor)
+
+    if has_gomod:
+        print("detected go.mod file")
+    if deps_vendored:
+        print("Detected vendor directory. Will skip downloading and initialization modules.")
+
     if os.environ.get("__NIM_REMOTE_BUILD"):
-        if exists(gomod):
-            print("downloading modules")
-            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
-            if ret != 0:
-                sys.exit(ret)
+        if has_gomod:
+            if not deps_vendored:
+                print("downloading modules")
+                ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
+                if ret != 0:
+                    sys.exit(ret)
         else:
-            print("initializing modules")
-            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
-            if ret != 0:
-                sys.exit(ret)
+            if not deps_vendored:
+                print("initializing modules")
+                ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
+                if ret != 0:
+                    sys.exit(ret)
     else:
         with open(os.devnull, "w") as dn:
-            if exists(gomod):
+            if has_gomod:
                 ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
                 if ret != 0:
                     print("cannot download modules")
@@ -111,7 +123,7 @@ def build(source_dir, target_dir):
                     return
 
     ldflags = "-s -w"
-    gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
+    gobuild = ["go", "build"] + (["-mod=vendor"] if deps_vendored else []) + ["-o", target, "-ldflags", ldflags]
     if os.environ.get("__OW_EXECUTION_ENV"):
         ldflags += " -X main.OwExecutionEnv=%s" % os.environ["__OW_EXECUTION_ENV"]
     if os.environ.get("__NIM_REMOTE_BUILD"):


### PR DESCRIPTION
This is the implementation described in https://docs.google.com/document/d/1sxNQvzDhinB4KkjHM_GWEjL_zj3B1dGBYu3pxhn1AjA/edit, done only for Go 1.17 so far.

If this is reviewed and nothing looks off, we'd do the same for every Go version we support at DO. So probably just 1.17.