### PR TITLE
Always intercept logs even if not remote logging

### DIFF
--- a/openwhisk/actionProxy_test.go
+++ b/openwhisk/actionProxy_test.go
@@ -55,7 +55,7 @@ func TestStartLatestAction_emit1(t *testing.T) {
 	buf := []byte("#!/bin/sh\nwhile read a; do echo 1 >&3 ; done\n")
 	ap.ExtractAction(&buf, "bin")
 	ap.StartLatestAction()
-	res, _ := ap.theExecutor.Interact([]byte("x"))
+	res, _ := ap.theExecutor.Interact([]byte("x"), false)
 	assert.Equal(t, res, []byte("1\n"))
 	ap.theExecutor.Stop()
 }
@@ -79,7 +79,7 @@ func TestStartLatestAction_emit2(t *testing.T) {
 	buf := []byte("#!/bin/sh\nwhile read a; do echo 2 >&3 ; done\n")
 	ap.ExtractAction(&buf, "bin")
 	ap.StartLatestAction()
-	res, _ := ap.theExecutor.Interact([]byte("z"))
+	res, _ := ap.theExecutor.Interact([]byte("z"), false)
 	assert.Equal(t, res, []byte("2\n"))
 	/**/
 	ap.theExecutor.Stop()

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -69,7 +69,7 @@ func (ap *ActionProxy) runHandler(w http.ResponseWriter, r *http.Request) {
 	body = bytes.Replace(body, []byte("\n"), []byte(""), -1)
 
 	// execute the action
-	response, err := ap.theExecutor.Interact(body)
+	response, err := ap.theExecutor.Interact(body, false)
 
 	// check for early termination
 	if err != nil {


### PR DESCRIPTION
Currently, we only intercept the log channels of the runtime process in the goproxy if we're using remote logging. That means that if we want to make use of remote logging, other features might not be usable, like runtime prelaunching.

This changes the behavior to ALWAYS intercept the log pipes and inserts a default logger that forwards to stdout and stderr, as today.

In doing so, this also fixes a bug where, when we've been using remote logging and the runtime would not write a sentinel, the process would timeout.