### PR TITLE
Drop superfluous newline from every result

### DIFF
--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -229,7 +229,7 @@ func (proc *Executor) roundtrip(in []byte) ([]byte, error) {
 	go func() {
 		out, err := proc.output.ReadBytes('\n')
 		if err == nil {
-			chout <- out
+			chout <- out[:len(out)-1] // Drop the last byte, which we know is a newline.
 		} else {
 			chout <- []byte{}
 		}


### PR DESCRIPTION
Currently, we return the newline we're using to delimit responses on fd3 to the invoker, because ReadBytes returns the bytes **including** the delimiter. It's unnecessary whitespace though and might as well be dropped. JSON-parsers will generally ignore it anyway.