### PR TITLE
SERVERLESS-2491 Rename action -> function in error messages

### DIFF
--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -70,7 +70,7 @@ func NewActionProxy(baseDir string, compiler string, outFile *os.File, errFile *
 	}
 }
 
-//SetEnv sets the environment
+// SetEnv sets the environment
 func (ap *ActionProxy) SetEnv(env map[string]interface{}) {
 	// Propagate some basic runtime environment
 	ap.env["HOME"] = os.Getenv("HOME")
@@ -121,7 +121,7 @@ func (ap *ActionProxy) StartLatestAction() error {
 	if highestDir == 0 {
 		Debug("no action found")
 		ap.theExecutor = nil
-		return fmt.Errorf("no valid actions available")
+		return fmt.Errorf("no valid functions available")
 	}
 
 	// check version

--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -239,7 +239,7 @@ func (proc *Executor) roundtrip(in []byte) ([]byte, error) {
 	select {
 	case out = <-chout:
 		if len(out) == 0 {
-			err = errors.New("no answer from the action")
+			err = errors.New("no answer from the function")
 		}
 	case <-proc.exited:
 		err = errors.New("command exited")
@@ -311,7 +311,7 @@ func (proc *Executor) Start(waitForAck bool) error {
 		}
 		// check ack
 		if !ackData.Ok {
-			ack <- fmt.Errorf("The action did not initialize properly.")
+			ack <- fmt.Errorf("The function did not initialize properly.")
 			return
 		}
 		ack <- nil

--- a/openwhisk/initHandler.go
+++ b/openwhisk/initHandler.go
@@ -55,7 +55,7 @@ func (ap *ActionProxy) initHandler(w http.ResponseWriter, r *http.Request) {
 
 	// you can do multiple initializations when debugging
 	if ap.initialized && !Debugging {
-		msg := "Cannot initialize the action more than once."
+		msg := "Cannot initialize the function more than once."
 		sendError(w, http.StatusForbidden, msg)
 		log.Println(msg)
 		return
@@ -139,24 +139,24 @@ func (ap *ActionProxy) scriptBasedInit(request initRequest) error {
 	_, err := ap.ExtractAndCompile(&buf, main)
 	if err != nil {
 		if os.Getenv("OW_LOG_INIT_ERROR") == "" {
-			return fmt.Errorf("cannot initialize action: %w", err)
+			return fmt.Errorf("cannot initialize function: %w", err)
 		}
 		ap.errFile.Write([]byte(err.Error() + "\n"))
 		ap.outFile.Write([]byte(OutputGuard))
 		ap.errFile.Write([]byte(OutputGuard))
-		return errors.New("The action failed to generate or locate a binary. See logs for details.")
+		return errors.New("The function failed to generate or locate a binary. See logs for details.")
 	}
 
 	// start an action
 	err = ap.StartLatestAction()
 	if err != nil {
 		if os.Getenv("OW_LOG_INIT_ERROR") == "" {
-			return fmt.Errorf("cannot start action: %w", err)
+			return fmt.Errorf("cannot start function: %w", err)
 		}
 		ap.errFile.Write([]byte(err.Error() + "\n"))
 		ap.outFile.Write([]byte(OutputGuard))
 		ap.errFile.Write([]byte(OutputGuard))
-		return errors.New("Cannot start action. Check logs for details.")
+		return errors.New("Cannot start function. Check logs for details.")
 	}
 	return nil
 }
@@ -165,12 +165,12 @@ func (ap *ActionProxy) actionloopBasedInit(request []byte) error {
 	out, err := ap.theExecutor.Interact(request)
 	if err != nil {
 		if os.Getenv("OW_LOG_INIT_ERROR") == "" {
-			return fmt.Errorf("cannot initialize action: %w", err)
+			return fmt.Errorf("cannot initialize function: %w", err)
 		}
 		ap.errFile.Write([]byte(err.Error() + "\n"))
 		ap.outFile.Write([]byte(OutputGuard))
 		ap.errFile.Write([]byte(OutputGuard))
-		return errors.New("Cannot initialize action. Check logs for details.")
+		return errors.New("Cannot initialize function. Check logs for details.")
 	}
 
 	var ackData ActionAck
@@ -178,7 +178,7 @@ func (ap *ActionProxy) actionloopBasedInit(request []byte) error {
 		return err
 	}
 	if !ackData.Ok {
-		return errors.New("The action did not initialize properly.")
+		return errors.New("The function did not initialize properly.")
 	}
 
 	return nil

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -56,7 +56,7 @@ func (ap *ActionProxy) runHandler(w http.ResponseWriter, r *http.Request) {
 
 	// check if you have an action
 	if ap.theExecutor == nil {
-		sendError(w, http.StatusInternalServerError, fmt.Sprintf("no action defined yet"))
+		sendError(w, http.StatusInternalServerError, fmt.Sprintf("no function defined yet"))
 		return
 	}
 	// check if the process exited
@@ -84,7 +84,7 @@ func (ap *ActionProxy) runHandler(w http.ResponseWriter, r *http.Request) {
 	var objmap map[string]*json.RawMessage
 	err = json.Unmarshal(response, &objmap)
 	if err != nil {
-		sendError(w, http.StatusBadGateway, "The action did not return a dictionary.")
+		sendError(w, http.StatusBadGateway, "The function did not return a dictionary.")
 		return
 	}
 


### PR DESCRIPTION
As per title, to be able to eliminate action terminology from error messages.