### PR TITLE
Added go 1.24 and 1.25

### DIFF
--- a/golang1.24/Dockerfile
+++ b/golang1.24/Dockerfile
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Do not fix the patch level for golang:1.24 to automatically get security fixes.
+FROM golang:1.24-bookworm
+
+# install the functions-deployer
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # For tests, mostly.
+    jq \
+    # To run the compile script.
+    python3 \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -sf /usr/bin/python3 /usr/bin/python \
+  && mkdir /action
+WORKDIR /action
+
+# This precompiles the standard library to make the build much quicker.
+RUN GODEBUG=installgoroot=all go install -a std
+
+COPY proxy /bin/proxy
+COPY bin/compile /bin/compile
+COPY lib/launcher.go /lib/launcher.go
+COPY defaultBuild /bin/defaultBuild
+
+ENV OW_COMPILER=/bin/compile
+ENV OW_LOG_INIT_ERROR=1
+ENV OW_WAIT_FOR_ACK=1
+
+ENTRYPOINT [ "/bin/proxy" ]

--- a/golang1.24/Makefile
+++ b/golang1.24/Makefile
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+IMG=action-golang-v1.24
+
+build:
+	../gradlew distDocker
+
+localbuild:
+	GOOS=linux GOARCH=amd64 go build -o proxy -a  -ldflags '-extldflags "-static"' ../main/proxy.go
+	docker build -t $(IMG) .
+	docker tag $(IMG) whisk/$(IMG)
+
+push: build
+	docker tag $(IMG) actionloop/$(IMG)
+	docker push actionloop/$(IMG):nightly
+
+clean:
+	docker rmi -f whisk/$(IMG) actionloop/$(IMG)
+
+debug: build
+	docker run -p 8080:8080 \
+	--name go-action --rm -ti --entrypoint=/bin/bash \
+	-e OW_COMPILER=/mnt/bin/compile \
+	-v $(PWD):/mnt whisk/$(IMG)
+
+enter:
+	docker exec -ti go-action bash
+
+
+.PHONY: build push clean debug enter

--- a/golang1.24/bin/compile
+++ b/golang1.24/bin/compile
@@ -1,0 +1,141 @@
+#!/usr/bin/python -u
+"""Golang Action Compiler
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+from __future__ import print_function
+import os, os.path, sys, re, subprocess, codecs
+from os.path import dirname, exists
+
+# write a file creating intermediate directories
+def write_file(file, body, executable=False):
+    try: os.makedirs(dirname(file), mode=0o755)
+    except: pass
+    with open(file, mode="wb") as f:
+        f.write(body)
+    if executable:
+        os.chmod(file, 0o755)
+
+# copy a file eventually replacing a substring
+def copy_replace(src, dst, match=None, replacement=""):
+    with open(src, 'rb') as s:
+        body = s.read()
+        if match:
+            body = body.replace(match, replacement)
+        write_file(dst, body)
+
+
+def sources(launcher, source_dir, main):
+    func = main
+    if func == "main":
+        # main is defaulted to "main" in the go-proxy. We want to fix that here.
+        func = "Main"
+    has_main = None
+
+    # copy the exec to exec.go
+    # also check if it has a main in it
+    src = "%s/exec" % source_dir
+    dst = "%s/exec__.go" % source_dir
+    if os.path.isfile(src):
+        with codecs.open(src, 'r', 'utf-8') as s:
+            with codecs.open(dst, 'w', 'utf-8') as d:
+                body = s.read()
+                has_main = re.match(r".*package\s+main\W.*func\s+main\s*\(\s*\)", body, flags=re.DOTALL)
+                d.write(body)
+
+    # copy the launcher fixing the main
+    if not has_main:
+        dst = "%s/main__.go" % source_dir
+        if os.path.isdir("%s/main" % source_dir):
+            dst = "%s/main/main__.go" % source_dir
+        with codecs.open(dst, 'w', 'utf-8') as d:
+            with codecs.open(launcher, 'r', 'utf-8') as e:
+                code = e.read()
+                code = code.replace("Main", func)
+                d.write(code)
+
+def build(source_dir, target_dir):
+    # compile...
+    source_dir = os.path.abspath(source_dir)
+    target = os.path.abspath("%s/exec" % target_dir)
+    if os.environ.get("__OW_EXECUTION_ENV"):
+      write_file("%s.env" % target, os.environ["__OW_EXECUTION_ENV"])
+
+    env = {
+      "GOROOT": "/usr/local/go",
+      "GOPATH": os.environ["HOME"]+"/go",
+      "PATH": os.environ["PATH"],
+      "GOCACHE": "/tmp",
+      "GO111MODULE": "on",
+      # Make use of the precompiled stdlib to make builds much quicker.
+      "GODEBUG": "installgoroot=all"
+    }
+
+    gomod = "%s/go.mod" % source_dir
+    if os.environ.get("__NIM_REMOTE_BUILD"):
+        if exists(gomod):
+            print("downloading modules")
+            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
+            if ret != 0:
+                sys.exit(ret)
+        else:
+            print("initializing modules")
+            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
+            if ret != 0:
+                sys.exit(ret)
+    else:
+        with open(os.devnull, "w") as dn:
+            if exists(gomod):
+                ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+                if ret != 0:
+                    print("cannot download modules")
+                    return
+            else:
+                ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+                if ret != 0:
+                    print("cannot init modules")
+                    return
+
+    ldflags = "-s -w"
+    gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
+    if os.environ.get("__OW_EXECUTION_ENV"):
+        ldflags += " -X main.OwExecutionEnv=%s" % os.environ["__OW_EXECUTION_ENV"]
+    if os.environ.get("__NIM_REMOTE_BUILD"):
+        print("building")
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            sys.exit(ret)
+    else:
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
+
+def main(argv):
+    if len(argv) < 4:
+        print("usage: <main-file> <source-dir> <target-dir>")
+        sys.exit(1)
+
+    main = argv[1]
+    source_dir = argv[2]
+    target_dir = argv[3]
+    launcher = dirname(dirname(argv[0]))+"/lib/launcher.go"
+    sources(launcher, source_dir, main)
+
+    build(source_dir, target_dir)
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/golang1.24/build.gradle
+++ b/golang1.24/build.gradle
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ext.dockerImageName = 'action-golang-v1.24'
+apply from: '../gradle/docker.gradle'
+
+distDocker.dependsOn 'staticBuildProxy'
+distDocker.dependsOn 'copyCompiler'
+distDocker.dependsOn 'copyRemoteBuilder'
+distDocker.dependsOn 'copyEpilogue'
+distDocker.finalizedBy('cleanup')
+
+task staticBuildProxy(type: Exec) {
+	environment CGO_ENABLED: "0"
+	environment GOOS: "linux"
+	environment GOARCH: "amd64"
+    environment GO111MODULE: "on"
+
+	commandLine 'go', 'build',
+		'-o',  'proxy', '-a',
+		'-ldflags', '-extldflags "-static"',
+		'../main/proxy.go'
+}
+
+task copyCompiler(type: Copy) {
+    from '../common/gobuild.py'
+    into '.'
+}
+
+task copyRemoteBuilder(type: Copy) {
+    from '../common/defaultBuild'
+    into '.'
+}
+
+task copyEpilogue(type: Copy) {
+    from '../common/gobuild.py.launcher.go'
+    into '.'
+}
+
+task cleanup(type: Delete) {
+    delete 'proxy'
+    delete 'defaultBuild'
+    delete 'gobuild.py'
+    delete 'gobuild.py.launcher.go'
+}

--- a/golang1.24/lib/launcher.go
+++ b/golang1.24/lib/launcher.go
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// OwExecutionEnv is the execution environment set at compile time
+var OwExecutionEnv = ""
+
+func main() {
+	// check if the execution environment is correct
+	if OwExecutionEnv != "" && OwExecutionEnv != os.Getenv("__OW_EXECUTION_ENV") {
+		fmt.Println("Execution Environment Mismatch")
+		fmt.Println("Expected: ", OwExecutionEnv)
+		fmt.Println("Actual: ", os.Getenv("__OW_EXECUTION_ENV"))
+		os.Exit(1)
+	}
+
+	// debugging
+	var debug = os.Getenv("OW_DEBUG") != ""
+	if debug {
+		f, err := os.OpenFile("/tmp/action.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err == nil {
+			log.SetOutput(f)
+		}
+		log.Printf("Environment: %v", os.Environ())
+	}
+
+	// input
+	out := os.NewFile(3, "pipe")
+	defer out.Close()
+	reader := bufio.NewReader(os.Stdin)
+
+	// validate that the function conforms to the supported interfaces
+	if err := validate(Main); err != nil {
+		fmt.Fprintf(os.Stderr, "Function does not conform to supported type: %s\n", err.Error())
+		fmt.Fprintf(out, `{"ok": false}%s`, "\n")
+		os.Exit(1)
+	}
+
+	// acknowledgement of started action
+	fmt.Fprintf(out, `{ "ok": true}%s`, "\n")
+	if debug {
+		log.Println("action started")
+	}
+
+	// read-eval-print loop
+	for {
+		// read one line
+		inbuf, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Println(err)
+			}
+			break
+		}
+		if debug {
+			log.Printf(">>>'%s'>>>", inbuf)
+		}
+		output, err := execute(Main, inbuf)
+		if err != nil {
+			output = []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
+		}
+		if debug {
+			log.Printf("<<<'%s'<<<", output)
+		}
+		fmt.Fprintf(out, "%s\n", output)
+
+		fmt.Fprintln(os.Stdout, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+		fmt.Fprintln(os.Stderr, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+	}
+}
+
+// execute parses the input into a value to pass to f and environment to set
+// for the duration of f and calls f with the respective value and environment.
+func execute(f interface{}, in []byte) ([]byte, error) {
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(in, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse input: %w", err)
+	}
+
+	// All values except "value" are expected to become environment variables.
+	for k, v := range input {
+		if k == "value" {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil {
+			os.Setenv("__OW_"+strings.ToUpper(k), s)
+		}
+	}
+
+	ctx, cancel, err := buildContext()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build context: %w", err)
+	}
+	if cancel != nil {
+		defer cancel()
+	}
+
+	// Process the value through the actual function
+	output, err := invoke(ctx, f, input["value"])
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanitize output.
+	output = bytes.ReplaceAll(output, []byte("\n"), []byte(""))
+	return output, nil
+}
+
+var (
+	errorInterface   = reflect.TypeOf((*error)(nil)).Elem()
+	contextInterface = reflect.TypeOf((*context.Context)(nil)).Elem()
+)
+
+// validate validates a given generic function f for supported
+func validate(f interface{}) error {
+	fun := reflect.ValueOf(f)
+	typ := fun.Type()
+
+	if numIn := typ.NumIn(); numIn > 2 {
+		return fmt.Errorf("at most 2 arguments are supported for the function, got %d", numIn)
+	} else if numIn == 2 && !typ.In(0).Implements(contextInterface) {
+		return fmt.Errorf("when passing 2 arguments, the first must be of type context.Context, got %s", typ.In(0).Name())
+	}
+
+	if numOut := typ.NumOut(); numOut > 2 {
+		return fmt.Errorf("at most 2 return values are supported for the function, got %d", numOut)
+	} else if numOut == 2 && !typ.Out(numOut-1).Implements(errorInterface) {
+		return fmt.Errorf("when expecting 2 return values, the last must be of type error, got %s", typ.Out(numOut-1).Name())
+	}
+
+	return nil
+}
+
+// invoke calls a generic function f with the given JSON in bytes, which is assumed
+// to be unmarshalable into a value argument of f, if present. If the function has a
+// return value other than error, it's expected to be marshalable to JSON.
+//
+// All permutations of the signatures defined in buildArguments and handleReturnValues
+// are supported.
+func invoke(ctx context.Context, f interface{}, in []byte) (out []byte, err error) {
+	defer func() {
+		// Transform a panic into an error response.
+		if p := recover(); p != nil {
+			err := fmt.Errorf("function panicked: %v", p)
+			out = []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
+		}
+	}()
+
+	fun := reflect.ValueOf(f)
+
+	arguments, err := buildArguments(ctx, fun, in)
+	if err != nil {
+		return nil, err
+	}
+	return handleReturnValues(fun.Call(arguments))
+}
+
+// buildArguments builds the arguments to call f.
+//
+// These argument signatures are supported:
+// - ()
+// - (context.Context)
+// - (Tin)
+// - (context.Context, Tin)
+func buildArguments(ctx context.Context, f reflect.Value, in []byte) ([]reflect.Value, error) {
+	typ := f.Type()
+	numArgs := typ.NumIn()
+
+	if numArgs == 0 {
+		// No arguments, exit early.
+		return nil, nil
+	}
+
+	if numArgs == 2 {
+		// We know that the first argument must be the context and the second the value here.
+		val := reflect.New(typ.In(1)).Interface()
+		if err := json.Unmarshal(in, val); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal input value: %w", err)
+		}
+		return []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(val).Elem()}, nil
+	}
+
+	// If there's only 1 argument, we need to figure out if it's only a context or only a value.
+	if typ.In(0).Implements(contextInterface) {
+		return []reflect.Value{reflect.ValueOf(ctx)}, nil
+	}
+
+	val := reflect.New(typ.In(0)).Interface()
+	if err := json.Unmarshal(in, val); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal input value: %w", err)
+	}
+	return []reflect.Value{reflect.ValueOf(val).Elem()}, nil
+}
+
+// buildContext builds a context suitable for executing the customer's function.
+//
+// Go's convention for contexts is to define a struct in the package you want to build contexts from and use a constant
+// instance of that struct as the key and define an exported function that other packages can use to retrieve a struct
+// with the data you want to convey from the context.
+// See https://github.com/aws/aws-lambda-go/blob/main/lambdacontext/context.go for an example of this.
+// If you need more than one key per package, you can define a struct type that you can put something like a string in
+// so that you can differentiate constant instances of the structs.
+// See https://github.com/golang/go/blob/master/src/net/http/server.go for an example of this.
+//
+// At DO, we don't yet offer a library our users can import as they write their functions, so we can't follow this
+// pattern right now. Therefore, the naming convention we use for our context keys doesn't matter. In the future, we can
+// change this by creating a library that our customers can use, at which point we will no longer have multiple context
+// keys and the single remaining context key will no longer be a string. Therefore, while we do need to communicate
+// these string keys to our customers for now, the naming convention we use for the strings doesn't matter. We've chosen
+// snake_case arbitrarily.
+//
+// Returns an error if it was unable to set up a deadline for the context because the deadline env var was present but
+// also invalid.
+func buildContext() (context.Context, context.CancelFunc, error) {
+	ctx := context.Background()
+
+	var cancel context.CancelFunc
+	if deadline := os.Getenv("__OW_DEADLINE"); deadline != "" {
+		// Set up a context that cancels at the given deadline.
+		deadlineMillis, err := strconv.ParseInt(os.Getenv("__OW_DEADLINE"), 10, 64)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse deadline: %w", err)
+		}
+		ctx, cancel = context.WithDeadline(ctx, time.UnixMilli(deadlineMillis))
+	}
+
+	// Unlike other programming languages we provide runtimes for, deadline is skipped because Go already has the
+	// built-in context deadlines, so our customers already have a way (which is better than if we added a value here)
+	// of retrieving the deadline.
+	ctx = context.WithValue(ctx, "function_name", os.Getenv("__OW_ACTION_NAME"))
+	ctx = context.WithValue(ctx, "function_version", os.Getenv("__OW_ACTION_VERSION"))
+	ctx = context.WithValue(ctx, "activation_id", os.Getenv("__OW_ACTIVATION_ID"))
+	ctx = context.WithValue(ctx, "request_id", os.Getenv("__OW_TRANSACTION_ID"))
+	ctx = context.WithValue(ctx, "api_host", os.Getenv("__OW_API_HOST"))
+	ctx = context.WithValue(ctx, "api_key", os.Getenv("__OW_API_KEY"))
+	ctx = context.WithValue(ctx, "namespace", os.Getenv("__OW_NAMESPACE"))
+
+	return ctx, cancel, nil
+}
+
+// handleReturnValues handles the values returned from a reflected function's call.
+//
+// These return value signatures are supported:
+// - <none>
+// - error
+// - Tout
+// - (Tout, error)
+func handleReturnValues(returns []reflect.Value) ([]byte, error) {
+	if len(returns) == 0 {
+		// If there's no return values, return a compatible empty JSON object.
+		return []byte("{}"), nil
+	}
+
+	if len(returns) == 2 {
+		if err := valueToError(returns[1]); err != nil {
+			// Transform the function error into an actual error return from the function.
+			// Return early as an error should always take precedence.
+			return []byte(fmt.Sprintf(`{"error": %q}`, err.Error())), nil
+		}
+
+		ret, err := json.Marshal(returns[0].Interface())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal output value: %w", err)
+		}
+		return ret, nil
+	}
+
+	// If there's only 1 return value, we need to figure out if it's only an error or only a value.
+	if returns[0].Type().Implements(errorInterface) {
+		if err := valueToError(returns[0]); err != nil {
+			// Transform the function error into an actual error return from the function.
+			// Return early as an error should always take precedence.
+			return []byte(fmt.Sprintf(`{"error": %q}`, err.Error())), nil
+		}
+		return []byte("{}"), nil
+	}
+
+	ret, err := json.Marshal(returns[0].Interface())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal output value: %w", err)
+	}
+	return ret, nil
+}
+
+// valueToError builds an error from the given reflect.Value, if there is one.
+func valueToError(val reflect.Value) error {
+	if err, ok := val.Interface().(error); ok && err != nil {
+		return err
+	}
+	return nil
+}

--- a/golang1.24/lib/launcher_test.go
+++ b/golang1.24/lib/launcher_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestTypeIn struct {
+	Foo string `json:"foo,omitempy"`
+}
+
+type TestTypeOut struct {
+	Bar string `json:"bar,omitempy"`
+}
+
+// cleanEnv removes all environment keys that are set by execute potentially.
+func cleanEnv() {
+	for _, e := range os.Environ() {
+		parts := strings.SplitN(e, "=", 2)
+		if strings.HasPrefix(parts[0], "__OW_") {
+			os.Unsetenv(parts[0])
+		}
+	}
+}
+
+func TestExecuteParsesEnvAndArgs(t *testing.T) {
+	defer cleanEnv()
+
+	f := func(arg map[string]interface{}) map[string]interface{} {
+		env := make(map[string]string)
+		for _, e := range os.Environ() {
+			parts := strings.SplitN(e, "=", 2)
+			if strings.HasPrefix(parts[0], "__OW_") {
+				env[parts[0]] = parts[1]
+			}
+		}
+
+		return map[string]interface{}{
+			"env": env,
+			"arg": arg,
+		}
+	}
+	in := []byte(`{"foo":"baz","value":{"testkey":"testvalue"},"key1":"val1","invalid":1}`)
+	want := []byte(`{"arg":{"testkey":"testvalue"},"env":{"__OW_FOO":"baz","__OW_KEY1":"val1"}}`)
+
+	out, err := execute(f, in)
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(out))
+}
+
+func TestExecuteParsesDeadline(t *testing.T) {
+	defer cleanEnv()
+
+	f := func(ctx context.Context) map[string]string {
+		deadline, _ := ctx.Deadline()
+		return map[string]string{
+			"deadline": deadline.String(),
+		}
+	}
+
+	deadline := time.Now().Add(10 * time.Second).UnixMilli()
+	in := []byte(fmt.Sprintf(`{"deadline":"%d","value":{"testkey":"testvalue"}}`, deadline))
+	// Rebuilding the time from milliseconds is important for the comparison.
+	want := []byte(fmt.Sprintf(`{"deadline":%q}`, time.UnixMilli(deadline).String()))
+
+	out, err := execute(f, in)
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(out))
+}
+
+func TestExecuteDefaultsToNoDeadline(t *testing.T) {
+	defer cleanEnv()
+
+	type ret struct {
+		Deadline *time.Time `json:"deadline,omitempty"`
+	}
+	f := func(ctx context.Context) ret {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return ret{}
+		}
+		return ret{Deadline: &deadline}
+	}
+
+	in := []byte(`{"value":{"testkey":"testvalue"}}`)
+	// We expect an empty object since the deadline should be unset.
+	want := []byte("{}")
+
+	out, err := execute(f, in)
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(out))
+}
+
+func TestInvoke(t *testing.T) {
+	inBytes := []byte(`{"foo":"baz"}`)
+	wantValue := []byte(`{"bar":"baz"}`)
+	wantNothing := []byte("{}")
+	wantError := []byte(fmt.Sprintf(`{"error": %q}`, assert.AnError.Error()))
+
+	tests := []struct {
+		name string
+		f    interface{}
+		want []byte
+	}{{
+		name: "backwards compat",
+		f: func(in map[string]interface{}) map[string]interface{} {
+			return map[string]interface{}{"bar": "baz"}
+		},
+		want: wantValue,
+	}, {
+		name: "func (): return nothing",
+		f:    func() {},
+		want: wantNothing,
+	}, {
+		name: "func () error: return nil",
+		f:    func() error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func () error: return error",
+		f:    func() error { return assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (TIn) error: return nil",
+		f:    func(in TestTypeIn) error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func () (TOut, error): returning value",
+		f: func() (TestTypeOut, error) {
+			return TestTypeOut{Bar: "baz"}, nil
+		},
+		want: wantValue,
+	}, {
+		name: "func () (TOut, error): returning error",
+		f: func() (TestTypeOut, error) {
+			return TestTypeOut{}, assert.AnError
+		},
+		want: wantError,
+	}, {
+		name: "func (Tin) (TOut, error): returning value", // not in Lambdas list
+		f: func(in *TestTypeIn) (*TestTypeOut, error) {
+			return &TestTypeOut{Bar: in.Foo}, nil
+		},
+		want: wantValue,
+	}, {
+		name: "func (Tin) (TOut, error): returning both, error takes precedence",
+		f: func(in *TestTypeIn) (*TestTypeOut, error) {
+			return &TestTypeOut{Bar: in.Foo}, assert.AnError
+		},
+		want: wantError,
+	}, {
+		name: "func (context.Context) error: return nil",
+		f:    func(context.Context) error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func (context.Context) error: return error",
+		f:    func(context.Context) error { return assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (context.Context, Tin) error: return nil",
+		f:    func(context.Context, TestTypeIn) error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func (context.Context, Tin) error: return error",
+		f:    func(context.Context, TestTypeIn) error { return assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (context.Context) (Tout, error): return value",
+		f:    func(context.Context) (TestTypeOut, error) { return TestTypeOut{Bar: "baz"}, nil },
+		want: wantValue,
+	}, {
+		name: "func (context.Context) (Tout, error): return error",
+		f:    func(context.Context) (TestTypeOut, error) { return TestTypeOut{Bar: "baz"}, assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (context.Context, Tin) (Tout, error): return value",
+		f:    func(ctx context.Context, in TestTypeIn) (TestTypeOut, error) { return TestTypeOut{Bar: in.Foo}, nil },
+		want: wantValue,
+	}, {
+		name: "func (context.Context, Tin) (Tout, error): return error",
+		f: func(ctx context.Context, in TestTypeIn) (TestTypeOut, error) {
+			return TestTypeOut{Bar: in.Foo}, assert.AnError
+		},
+		want: wantError,
+	}, {
+		name: "panic: return error",
+		f: func() {
+			panic("test")
+		},
+		want: []byte(`{"error":"function panicked: test"}`),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := invoke(context.Background(), tt.f, inBytes)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		f         interface{}
+		wantError bool
+	}{{
+		name: "backwards compat",
+		f: func(in map[string]interface{}) map[string]interface{} {
+			return map[string]interface{}{"bar": "baz"}
+		},
+	}, {
+		name: "func ()",
+		f:    func() {},
+	}, {
+		name: "func () error",
+		f:    func() error { return nil },
+	}, {
+		name: "func (TIn) error",
+		f:    func(in TestTypeIn) error { return nil },
+	}, {
+		name: "func () (TOut, error)",
+		f: func() (TestTypeOut, error) {
+			return TestTypeOut{Bar: "baz"}, nil
+		},
+	}, {
+		name: "func (Tin) (TOut, error)", // not in Lambdas list
+		f: func(in *TestTypeIn) (*TestTypeOut, error) {
+			return &TestTypeOut{Bar: in.Foo}, nil
+		},
+	}, {
+		name: "func (context.Context) error",
+		f:    func(context.Context) error { return nil },
+	}, {
+		name: "func (context.Context, Tin) error",
+		f:    func(context.Context, TestTypeIn) error { return nil },
+	}, {
+		name: "func (context.Context) (Tout, error)",
+		f:    func(context.Context) (TestTypeOut, error) { return TestTypeOut{Bar: "baz"}, nil },
+	}, {
+		name: "func (context.Context, Tin) (Tout, error)",
+		f:    func(ctx context.Context, in TestTypeIn) (TestTypeOut, error) { return TestTypeOut{Bar: in.Foo}, nil },
+	}, {
+		name:      "too many arguments",
+		f:         func(context.Context, TestTypeIn, string) { return },
+		wantError: true,
+	}, {
+		name:      "wrong arguments",
+		f:         func(TestTypeIn, context.Context) { return },
+		wantError: true,
+	}, {
+		name:      "too many return values",
+		f:         func() (string, string, string) { return "", "", "" },
+		wantError: true,
+	}, {
+		name:      "wrong return values",
+		f:         func() (error, string) { return assert.AnError, "" },
+		wantError: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate(tt.f)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/golang1.25/Dockerfile
+++ b/golang1.25/Dockerfile
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Do not fix the patch level for golang:1.25 to automatically get security fixes.
+FROM golang:1.25-bookworm
+
+# install the functions-deployer
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # For tests, mostly.
+    jq \
+    # To run the compile script.
+    python3 \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -sf /usr/bin/python3 /usr/bin/python \
+  && mkdir /action
+WORKDIR /action
+
+# This precompiles the standard library to make the build much quicker.
+RUN GODEBUG=installgoroot=all go install -a std
+
+COPY proxy /bin/proxy
+COPY bin/compile /bin/compile
+COPY lib/launcher.go /lib/launcher.go
+COPY defaultBuild /bin/defaultBuild
+
+ENV OW_COMPILER=/bin/compile
+ENV OW_LOG_INIT_ERROR=1
+ENV OW_WAIT_FOR_ACK=1
+
+ENTRYPOINT [ "/bin/proxy" ]

--- a/golang1.25/Makefile
+++ b/golang1.25/Makefile
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+IMG=action-golang-v1.25
+
+build:
+	../gradlew distDocker
+
+localbuild:
+	GOOS=linux GOARCH=amd64 go build -o proxy -a  -ldflags '-extldflags "-static"' ../main/proxy.go
+	docker build -t $(IMG) .
+	docker tag $(IMG) whisk/$(IMG)
+
+push: build
+	docker tag $(IMG) actionloop/$(IMG)
+	docker push actionloop/$(IMG):nightly
+
+clean:
+	docker rmi -f whisk/$(IMG) actionloop/$(IMG)
+
+debug: build
+	docker run -p 8080:8080 \
+	--name go-action --rm -ti --entrypoint=/bin/bash \
+	-e OW_COMPILER=/mnt/bin/compile \
+	-v $(PWD):/mnt whisk/$(IMG)
+
+enter:
+	docker exec -ti go-action bash
+
+
+.PHONY: build push clean debug enter

--- a/golang1.25/bin/compile
+++ b/golang1.25/bin/compile
@@ -1,0 +1,141 @@
+#!/usr/bin/python -u
+"""Golang Action Compiler
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+from __future__ import print_function
+import os, os.path, sys, re, subprocess, codecs
+from os.path import dirname, exists
+
+# write a file creating intermediate directories
+def write_file(file, body, executable=False):
+    try: os.makedirs(dirname(file), mode=0o755)
+    except: pass
+    with open(file, mode="wb") as f:
+        f.write(body)
+    if executable:
+        os.chmod(file, 0o755)
+
+# copy a file eventually replacing a substring
+def copy_replace(src, dst, match=None, replacement=""):
+    with open(src, 'rb') as s:
+        body = s.read()
+        if match:
+            body = body.replace(match, replacement)
+        write_file(dst, body)
+
+
+def sources(launcher, source_dir, main):
+    func = main
+    if func == "main":
+        # main is defaulted to "main" in the go-proxy. We want to fix that here.
+        func = "Main"
+    has_main = None
+
+    # copy the exec to exec.go
+    # also check if it has a main in it
+    src = "%s/exec" % source_dir
+    dst = "%s/exec__.go" % source_dir
+    if os.path.isfile(src):
+        with codecs.open(src, 'r', 'utf-8') as s:
+            with codecs.open(dst, 'w', 'utf-8') as d:
+                body = s.read()
+                has_main = re.match(r".*package\s+main\W.*func\s+main\s*\(\s*\)", body, flags=re.DOTALL)
+                d.write(body)
+
+    # copy the launcher fixing the main
+    if not has_main:
+        dst = "%s/main__.go" % source_dir
+        if os.path.isdir("%s/main" % source_dir):
+            dst = "%s/main/main__.go" % source_dir
+        with codecs.open(dst, 'w', 'utf-8') as d:
+            with codecs.open(launcher, 'r', 'utf-8') as e:
+                code = e.read()
+                code = code.replace("Main", func)
+                d.write(code)
+
+def build(source_dir, target_dir):
+    # compile...
+    source_dir = os.path.abspath(source_dir)
+    target = os.path.abspath("%s/exec" % target_dir)
+    if os.environ.get("__OW_EXECUTION_ENV"):
+      write_file("%s.env" % target, os.environ["__OW_EXECUTION_ENV"])
+
+    env = {
+      "GOROOT": "/usr/local/go",
+      "GOPATH": os.environ["HOME"]+"/go",
+      "PATH": os.environ["PATH"],
+      "GOCACHE": "/tmp",
+      "GO111MODULE": "on",
+      # Make use of the precompiled stdlib to make builds much quicker.
+      "GODEBUG": "installgoroot=all"
+    }
+
+    gomod = "%s/go.mod" % source_dir
+    if os.environ.get("__NIM_REMOTE_BUILD"):
+        if exists(gomod):
+            print("downloading modules")
+            ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env)
+            if ret != 0:
+                sys.exit(ret)
+        else:
+            print("initializing modules")
+            ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env)
+            if ret != 0:
+                sys.exit(ret)
+    else:
+        with open(os.devnull, "w") as dn:
+            if exists(gomod):
+                ret = subprocess.call(["go", "mod", "download"], cwd=source_dir, env=env, stderr=dn, stdout=dn)
+                if ret != 0:
+                    print("cannot download modules")
+                    return
+            else:
+                ret = subprocess.call(["go", "mod", "init", "exec"], cwd=source_dir, env=env, stdout=dn, stderr=dn)
+                if ret != 0:
+                    print("cannot init modules")
+                    return
+
+    ldflags = "-s -w"
+    gobuild = ["go", "build", "-o", target, "-ldflags", ldflags]
+    if os.environ.get("__OW_EXECUTION_ENV"):
+        ldflags += " -X main.OwExecutionEnv=%s" % os.environ["__OW_EXECUTION_ENV"]
+    if os.environ.get("__NIM_REMOTE_BUILD"):
+        print("building")
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            sys.exit(ret)
+    else:
+        ret = subprocess.call(gobuild, cwd=source_dir, env=env)
+        if ret != 0:
+            print("failed", " ".join(gobuild), "\nin", source_dir, "\nenv", env)
+
+def main(argv):
+    if len(argv) < 4:
+        print("usage: <main-file> <source-dir> <target-dir>")
+        sys.exit(1)
+
+    main = argv[1]
+    source_dir = argv[2]
+    target_dir = argv[3]
+    launcher = dirname(dirname(argv[0]))+"/lib/launcher.go"
+    sources(launcher, source_dir, main)
+
+    build(source_dir, target_dir)
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/golang1.25/build.gradle
+++ b/golang1.25/build.gradle
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ext.dockerImageName = 'action-golang-v1.25'
+apply from: '../gradle/docker.gradle'
+
+distDocker.dependsOn 'staticBuildProxy'
+distDocker.dependsOn 'copyCompiler'
+distDocker.dependsOn 'copyRemoteBuilder'
+distDocker.dependsOn 'copyEpilogue'
+distDocker.finalizedBy('cleanup')
+
+task staticBuildProxy(type: Exec) {
+	environment CGO_ENABLED: "0"
+	environment GOOS: "linux"
+	environment GOARCH: "amd64"
+    environment GO111MODULE: "on"
+
+	commandLine 'go', 'build',
+		'-o',  'proxy', '-a',
+		'-ldflags', '-extldflags "-static"',
+		'../main/proxy.go'
+}
+
+task copyCompiler(type: Copy) {
+    from '../common/gobuild.py'
+    into '.'
+}
+
+task copyRemoteBuilder(type: Copy) {
+    from '../common/defaultBuild'
+    into '.'
+}
+
+task copyEpilogue(type: Copy) {
+    from '../common/gobuild.py.launcher.go'
+    into '.'
+}
+
+task cleanup(type: Delete) {
+    delete 'proxy'
+    delete 'defaultBuild'
+    delete 'gobuild.py'
+    delete 'gobuild.py.launcher.go'
+}

--- a/golang1.25/lib/launcher.go
+++ b/golang1.25/lib/launcher.go
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// OwExecutionEnv is the execution environment set at compile time
+var OwExecutionEnv = ""
+
+func main() {
+	// check if the execution environment is correct
+	if OwExecutionEnv != "" && OwExecutionEnv != os.Getenv("__OW_EXECUTION_ENV") {
+		fmt.Println("Execution Environment Mismatch")
+		fmt.Println("Expected: ", OwExecutionEnv)
+		fmt.Println("Actual: ", os.Getenv("__OW_EXECUTION_ENV"))
+		os.Exit(1)
+	}
+
+	// debugging
+	var debug = os.Getenv("OW_DEBUG") != ""
+	if debug {
+		f, err := os.OpenFile("/tmp/action.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err == nil {
+			log.SetOutput(f)
+		}
+		log.Printf("Environment: %v", os.Environ())
+	}
+
+	// input
+	out := os.NewFile(3, "pipe")
+	defer out.Close()
+	reader := bufio.NewReader(os.Stdin)
+
+	// validate that the function conforms to the supported interfaces
+	if err := validate(Main); err != nil {
+		fmt.Fprintf(os.Stderr, "Function does not conform to supported type: %s\n", err.Error())
+		fmt.Fprintf(out, `{"ok": false}%s`, "\n")
+		os.Exit(1)
+	}
+
+	// acknowledgement of started action
+	fmt.Fprintf(out, `{ "ok": true}%s`, "\n")
+	if debug {
+		log.Println("action started")
+	}
+
+	// read-eval-print loop
+	for {
+		// read one line
+		inbuf, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Println(err)
+			}
+			break
+		}
+		if debug {
+			log.Printf(">>>'%s'>>>", inbuf)
+		}
+		output, err := execute(Main, inbuf)
+		if err != nil {
+			output = []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
+		}
+		if debug {
+			log.Printf("<<<'%s'<<<", output)
+		}
+		fmt.Fprintf(out, "%s\n", output)
+
+		fmt.Fprintln(os.Stdout, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+		fmt.Fprintln(os.Stderr, "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+	}
+}
+
+// execute parses the input into a value to pass to f and environment to set
+// for the duration of f and calls f with the respective value and environment.
+func execute(f interface{}, in []byte) ([]byte, error) {
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(in, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse input: %w", err)
+	}
+
+	// All values except "value" are expected to become environment variables.
+	for k, v := range input {
+		if k == "value" {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil {
+			os.Setenv("__OW_"+strings.ToUpper(k), s)
+		}
+	}
+
+	ctx, cancel, err := buildContext()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build context: %w", err)
+	}
+	if cancel != nil {
+		defer cancel()
+	}
+
+	// Process the value through the actual function
+	output, err := invoke(ctx, f, input["value"])
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanitize output.
+	output = bytes.ReplaceAll(output, []byte("\n"), []byte(""))
+	return output, nil
+}
+
+var (
+	errorInterface   = reflect.TypeOf((*error)(nil)).Elem()
+	contextInterface = reflect.TypeOf((*context.Context)(nil)).Elem()
+)
+
+// validate validates a given generic function f for supported
+func validate(f interface{}) error {
+	fun := reflect.ValueOf(f)
+	typ := fun.Type()
+
+	if numIn := typ.NumIn(); numIn > 2 {
+		return fmt.Errorf("at most 2 arguments are supported for the function, got %d", numIn)
+	} else if numIn == 2 && !typ.In(0).Implements(contextInterface) {
+		return fmt.Errorf("when passing 2 arguments, the first must be of type context.Context, got %s", typ.In(0).Name())
+	}
+
+	if numOut := typ.NumOut(); numOut > 2 {
+		return fmt.Errorf("at most 2 return values are supported for the function, got %d", numOut)
+	} else if numOut == 2 && !typ.Out(numOut-1).Implements(errorInterface) {
+		return fmt.Errorf("when expecting 2 return values, the last must be of type error, got %s", typ.Out(numOut-1).Name())
+	}
+
+	return nil
+}
+
+// invoke calls a generic function f with the given JSON in bytes, which is assumed
+// to be unmarshalable into a value argument of f, if present. If the function has a
+// return value other than error, it's expected to be marshalable to JSON.
+//
+// All permutations of the signatures defined in buildArguments and handleReturnValues
+// are supported.
+func invoke(ctx context.Context, f interface{}, in []byte) (out []byte, err error) {
+	defer func() {
+		// Transform a panic into an error response.
+		if p := recover(); p != nil {
+			err := fmt.Errorf("function panicked: %v", p)
+			out = []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
+		}
+	}()
+
+	fun := reflect.ValueOf(f)
+
+	arguments, err := buildArguments(ctx, fun, in)
+	if err != nil {
+		return nil, err
+	}
+	return handleReturnValues(fun.Call(arguments))
+}
+
+// buildArguments builds the arguments to call f.
+//
+// These argument signatures are supported:
+// - ()
+// - (context.Context)
+// - (Tin)
+// - (context.Context, Tin)
+func buildArguments(ctx context.Context, f reflect.Value, in []byte) ([]reflect.Value, error) {
+	typ := f.Type()
+	numArgs := typ.NumIn()
+
+	if numArgs == 0 {
+		// No arguments, exit early.
+		return nil, nil
+	}
+
+	if numArgs == 2 {
+		// We know that the first argument must be the context and the second the value here.
+		val := reflect.New(typ.In(1)).Interface()
+		if err := json.Unmarshal(in, val); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal input value: %w", err)
+		}
+		return []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(val).Elem()}, nil
+	}
+
+	// If there's only 1 argument, we need to figure out if it's only a context or only a value.
+	if typ.In(0).Implements(contextInterface) {
+		return []reflect.Value{reflect.ValueOf(ctx)}, nil
+	}
+
+	val := reflect.New(typ.In(0)).Interface()
+	if err := json.Unmarshal(in, val); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal input value: %w", err)
+	}
+	return []reflect.Value{reflect.ValueOf(val).Elem()}, nil
+}
+
+// buildContext builds a context suitable for executing the customer's function.
+//
+// Go's convention for contexts is to define a struct in the package you want to build contexts from and use a constant
+// instance of that struct as the key and define an exported function that other packages can use to retrieve a struct
+// with the data you want to convey from the context.
+// See https://github.com/aws/aws-lambda-go/blob/main/lambdacontext/context.go for an example of this.
+// If you need more than one key per package, you can define a struct type that you can put something like a string in
+// so that you can differentiate constant instances of the structs.
+// See https://github.com/golang/go/blob/master/src/net/http/server.go for an example of this.
+//
+// At DO, we don't yet offer a library our users can import as they write their functions, so we can't follow this
+// pattern right now. Therefore, the naming convention we use for our context keys doesn't matter. In the future, we can
+// change this by creating a library that our customers can use, at which point we will no longer have multiple context
+// keys and the single remaining context key will no longer be a string. Therefore, while we do need to communicate
+// these string keys to our customers for now, the naming convention we use for the strings doesn't matter. We've chosen
+// snake_case arbitrarily.
+//
+// Returns an error if it was unable to set up a deadline for the context because the deadline env var was present but
+// also invalid.
+func buildContext() (context.Context, context.CancelFunc, error) {
+	ctx := context.Background()
+
+	var cancel context.CancelFunc
+	if deadline := os.Getenv("__OW_DEADLINE"); deadline != "" {
+		// Set up a context that cancels at the given deadline.
+		deadlineMillis, err := strconv.ParseInt(os.Getenv("__OW_DEADLINE"), 10, 64)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse deadline: %w", err)
+		}
+		ctx, cancel = context.WithDeadline(ctx, time.UnixMilli(deadlineMillis))
+	}
+
+	// Unlike other programming languages we provide runtimes for, deadline is skipped because Go already has the
+	// built-in context deadlines, so our customers already have a way (which is better than if we added a value here)
+	// of retrieving the deadline.
+	ctx = context.WithValue(ctx, "function_name", os.Getenv("__OW_ACTION_NAME"))
+	ctx = context.WithValue(ctx, "function_version", os.Getenv("__OW_ACTION_VERSION"))
+	ctx = context.WithValue(ctx, "activation_id", os.Getenv("__OW_ACTIVATION_ID"))
+	ctx = context.WithValue(ctx, "request_id", os.Getenv("__OW_TRANSACTION_ID"))
+	ctx = context.WithValue(ctx, "api_host", os.Getenv("__OW_API_HOST"))
+	ctx = context.WithValue(ctx, "api_key", os.Getenv("__OW_API_KEY"))
+	ctx = context.WithValue(ctx, "namespace", os.Getenv("__OW_NAMESPACE"))
+
+	return ctx, cancel, nil
+}
+
+// handleReturnValues handles the values returned from a reflected function's call.
+//
+// These return value signatures are supported:
+// - <none>
+// - error
+// - Tout
+// - (Tout, error)
+func handleReturnValues(returns []reflect.Value) ([]byte, error) {
+	if len(returns) == 0 {
+		// If there's no return values, return a compatible empty JSON object.
+		return []byte("{}"), nil
+	}
+
+	if len(returns) == 2 {
+		if err := valueToError(returns[1]); err != nil {
+			// Transform the function error into an actual error return from the function.
+			// Return early as an error should always take precedence.
+			return []byte(fmt.Sprintf(`{"error": %q}`, err.Error())), nil
+		}
+
+		ret, err := json.Marshal(returns[0].Interface())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal output value: %w", err)
+		}
+		return ret, nil
+	}
+
+	// If there's only 1 return value, we need to figure out if it's only an error or only a value.
+	if returns[0].Type().Implements(errorInterface) {
+		if err := valueToError(returns[0]); err != nil {
+			// Transform the function error into an actual error return from the function.
+			// Return early as an error should always take precedence.
+			return []byte(fmt.Sprintf(`{"error": %q}`, err.Error())), nil
+		}
+		return []byte("{}"), nil
+	}
+
+	ret, err := json.Marshal(returns[0].Interface())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal output value: %w", err)
+	}
+	return ret, nil
+}
+
+// valueToError builds an error from the given reflect.Value, if there is one.
+func valueToError(val reflect.Value) error {
+	if err, ok := val.Interface().(error); ok && err != nil {
+		return err
+	}
+	return nil
+}

--- a/golang1.25/lib/launcher_test.go
+++ b/golang1.25/lib/launcher_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestTypeIn struct {
+	Foo string `json:"foo,omitempy"`
+}
+
+type TestTypeOut struct {
+	Bar string `json:"bar,omitempy"`
+}
+
+// cleanEnv removes all environment keys that are set by execute potentially.
+func cleanEnv() {
+	for _, e := range os.Environ() {
+		parts := strings.SplitN(e, "=", 2)
+		if strings.HasPrefix(parts[0], "__OW_") {
+			os.Unsetenv(parts[0])
+		}
+	}
+}
+
+func TestExecuteParsesEnvAndArgs(t *testing.T) {
+	defer cleanEnv()
+
+	f := func(arg map[string]interface{}) map[string]interface{} {
+		env := make(map[string]string)
+		for _, e := range os.Environ() {
+			parts := strings.SplitN(e, "=", 2)
+			if strings.HasPrefix(parts[0], "__OW_") {
+				env[parts[0]] = parts[1]
+			}
+		}
+
+		return map[string]interface{}{
+			"env": env,
+			"arg": arg,
+		}
+	}
+	in := []byte(`{"foo":"baz","value":{"testkey":"testvalue"},"key1":"val1","invalid":1}`)
+	want := []byte(`{"arg":{"testkey":"testvalue"},"env":{"__OW_FOO":"baz","__OW_KEY1":"val1"}}`)
+
+	out, err := execute(f, in)
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(out))
+}
+
+func TestExecuteParsesDeadline(t *testing.T) {
+	defer cleanEnv()
+
+	f := func(ctx context.Context) map[string]string {
+		deadline, _ := ctx.Deadline()
+		return map[string]string{
+			"deadline": deadline.String(),
+		}
+	}
+
+	deadline := time.Now().Add(10 * time.Second).UnixMilli()
+	in := []byte(fmt.Sprintf(`{"deadline":"%d","value":{"testkey":"testvalue"}}`, deadline))
+	// Rebuilding the time from milliseconds is important for the comparison.
+	want := []byte(fmt.Sprintf(`{"deadline":%q}`, time.UnixMilli(deadline).String()))
+
+	out, err := execute(f, in)
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(out))
+}
+
+func TestExecuteDefaultsToNoDeadline(t *testing.T) {
+	defer cleanEnv()
+
+	type ret struct {
+		Deadline *time.Time `json:"deadline,omitempty"`
+	}
+	f := func(ctx context.Context) ret {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return ret{}
+		}
+		return ret{Deadline: &deadline}
+	}
+
+	in := []byte(`{"value":{"testkey":"testvalue"}}`)
+	// We expect an empty object since the deadline should be unset.
+	want := []byte("{}")
+
+	out, err := execute(f, in)
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(out))
+}
+
+func TestInvoke(t *testing.T) {
+	inBytes := []byte(`{"foo":"baz"}`)
+	wantValue := []byte(`{"bar":"baz"}`)
+	wantNothing := []byte("{}")
+	wantError := []byte(fmt.Sprintf(`{"error": %q}`, assert.AnError.Error()))
+
+	tests := []struct {
+		name string
+		f    interface{}
+		want []byte
+	}{{
+		name: "backwards compat",
+		f: func(in map[string]interface{}) map[string]interface{} {
+			return map[string]interface{}{"bar": "baz"}
+		},
+		want: wantValue,
+	}, {
+		name: "func (): return nothing",
+		f:    func() {},
+		want: wantNothing,
+	}, {
+		name: "func () error: return nil",
+		f:    func() error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func () error: return error",
+		f:    func() error { return assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (TIn) error: return nil",
+		f:    func(in TestTypeIn) error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func () (TOut, error): returning value",
+		f: func() (TestTypeOut, error) {
+			return TestTypeOut{Bar: "baz"}, nil
+		},
+		want: wantValue,
+	}, {
+		name: "func () (TOut, error): returning error",
+		f: func() (TestTypeOut, error) {
+			return TestTypeOut{}, assert.AnError
+		},
+		want: wantError,
+	}, {
+		name: "func (Tin) (TOut, error): returning value", // not in Lambdas list
+		f: func(in *TestTypeIn) (*TestTypeOut, error) {
+			return &TestTypeOut{Bar: in.Foo}, nil
+		},
+		want: wantValue,
+	}, {
+		name: "func (Tin) (TOut, error): returning both, error takes precedence",
+		f: func(in *TestTypeIn) (*TestTypeOut, error) {
+			return &TestTypeOut{Bar: in.Foo}, assert.AnError
+		},
+		want: wantError,
+	}, {
+		name: "func (context.Context) error: return nil",
+		f:    func(context.Context) error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func (context.Context) error: return error",
+		f:    func(context.Context) error { return assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (context.Context, Tin) error: return nil",
+		f:    func(context.Context, TestTypeIn) error { return nil },
+		want: wantNothing,
+	}, {
+		name: "func (context.Context, Tin) error: return error",
+		f:    func(context.Context, TestTypeIn) error { return assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (context.Context) (Tout, error): return value",
+		f:    func(context.Context) (TestTypeOut, error) { return TestTypeOut{Bar: "baz"}, nil },
+		want: wantValue,
+	}, {
+		name: "func (context.Context) (Tout, error): return error",
+		f:    func(context.Context) (TestTypeOut, error) { return TestTypeOut{Bar: "baz"}, assert.AnError },
+		want: wantError,
+	}, {
+		name: "func (context.Context, Tin) (Tout, error): return value",
+		f:    func(ctx context.Context, in TestTypeIn) (TestTypeOut, error) { return TestTypeOut{Bar: in.Foo}, nil },
+		want: wantValue,
+	}, {
+		name: "func (context.Context, Tin) (Tout, error): return error",
+		f: func(ctx context.Context, in TestTypeIn) (TestTypeOut, error) {
+			return TestTypeOut{Bar: in.Foo}, assert.AnError
+		},
+		want: wantError,
+	}, {
+		name: "panic: return error",
+		f: func() {
+			panic("test")
+		},
+		want: []byte(`{"error":"function panicked: test"}`),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := invoke(context.Background(), tt.f, inBytes)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		f         interface{}
+		wantError bool
+	}{{
+		name: "backwards compat",
+		f: func(in map[string]interface{}) map[string]interface{} {
+			return map[string]interface{}{"bar": "baz"}
+		},
+	}, {
+		name: "func ()",
+		f:    func() {},
+	}, {
+		name: "func () error",
+		f:    func() error { return nil },
+	}, {
+		name: "func (TIn) error",
+		f:    func(in TestTypeIn) error { return nil },
+	}, {
+		name: "func () (TOut, error)",
+		f: func() (TestTypeOut, error) {
+			return TestTypeOut{Bar: "baz"}, nil
+		},
+	}, {
+		name: "func (Tin) (TOut, error)", // not in Lambdas list
+		f: func(in *TestTypeIn) (*TestTypeOut, error) {
+			return &TestTypeOut{Bar: in.Foo}, nil
+		},
+	}, {
+		name: "func (context.Context) error",
+		f:    func(context.Context) error { return nil },
+	}, {
+		name: "func (context.Context, Tin) error",
+		f:    func(context.Context, TestTypeIn) error { return nil },
+	}, {
+		name: "func (context.Context) (Tout, error)",
+		f:    func(context.Context) (TestTypeOut, error) { return TestTypeOut{Bar: "baz"}, nil },
+	}, {
+		name: "func (context.Context, Tin) (Tout, error)",
+		f:    func(ctx context.Context, in TestTypeIn) (TestTypeOut, error) { return TestTypeOut{Bar: in.Foo}, nil },
+	}, {
+		name:      "too many arguments",
+		f:         func(context.Context, TestTypeIn, string) { return },
+		wantError: true,
+	}, {
+		name:      "wrong arguments",
+		f:         func(TestTypeIn, context.Context) { return },
+		wantError: true,
+	}, {
+		name:      "too many return values",
+		f:         func() (string, string, string) { return "", "", "" },
+		wantError: true,
+	}, {
+		name:      "wrong return values",
+		f:         func() (error, string) { return assert.AnError, "" },
+		wantError: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate(tt.f)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGo24Tests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGo24Tests.scala
@@ -14,35 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package runtime.actionContainers
 
-include 'tests'
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
-include 'actionloop'
-include 'golang1.12'
-include 'golang1.13'
-include 'golang1.15'
-include 'golang1.16'
-include 'golang1.17'
-include 'golang1.20'
-include 'golang1.24'
-include 'golang1.25'
+@RunWith(classOf[JUnitRunner])
+class ActionLoopBasicGo24Tests
+    extends ActionLoopBasicGoTests
+    with WskActorSystem {
 
-rootProject.name = 'runtime-golang'
-
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    depVersion  : '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.akka = [version : '2.5.32']
-gradle.ext.akka_http = [version : '10.1.15']
+  override lazy val goCompiler = "action-golang-v1.24"
+  override lazy val image = goCompiler
+  override lazy val requireAck = true
+}

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGo25Tests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopBasicGo25Tests.scala
@@ -14,35 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package runtime.actionContainers
 
-include 'tests'
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
-include 'actionloop'
-include 'golang1.12'
-include 'golang1.13'
-include 'golang1.15'
-include 'golang1.16'
-include 'golang1.17'
-include 'golang1.20'
-include 'golang1.24'
-include 'golang1.25'
+@RunWith(classOf[JUnitRunner])
+class ActionLoopBasicGo25Tests
+    extends ActionLoopBasicGoTests
+    with WskActorSystem {
 
-rootProject.name = 'runtime-golang'
-
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    depVersion  : '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.akka = [version : '2.5.32']
-gradle.ext.akka_http = [version : '10.1.15']
+  override lazy val goCompiler = "action-golang-v1.25"
+  override lazy val image = goCompiler
+  override lazy val requireAck = true
+}

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopGo24ContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopGo24ContainerTests.scala
@@ -15,34 +15,17 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'actionloop'
-include 'golang1.12'
-include 'golang1.13'
-include 'golang1.15'
-include 'golang1.16'
-include 'golang1.17'
-include 'golang1.20'
-include 'golang1.24'
-include 'golang1.25'
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+@RunWith(classOf[JUnitRunner])
+class ActionLoopGo24ContainerTests
+    extends ActionLoopGoContainerTests
+    with WskActorSystem {
 
-rootProject.name = 'runtime-golang'
+  override lazy val goCompiler = "action-golang-v1.24"
+  override lazy val image = goCompiler
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    depVersion  : '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.akka = [version : '2.5.32']
-gradle.ext.akka_http = [version : '10.1.15']
+}

--- a/tests/src/test/scala/runtime/actionContainers/ActionLoopGo25ContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/ActionLoopGo25ContainerTests.scala
@@ -15,34 +15,17 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'actionloop'
-include 'golang1.12'
-include 'golang1.13'
-include 'golang1.15'
-include 'golang1.16'
-include 'golang1.17'
-include 'golang1.20'
-include 'golang1.24'
-include 'golang1.25'
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+@RunWith(classOf[JUnitRunner])
+class ActionLoopGo25ContainerTests
+    extends ActionLoopGoContainerTests
+    with WskActorSystem {
 
-rootProject.name = 'runtime-golang'
+  override lazy val goCompiler = "action-golang-v1.25"
+  override lazy val image = goCompiler
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    depVersion  : '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.akka = [version : '2.5.32']
-gradle.ext.akka_http = [version : '10.1.15']
+}


### PR DESCRIPTION
This PR adds support for go 1.24 and 1.25 using the golang:1.24-bookworm and golang:1.25-bookworm base image.